### PR TITLE
Version 2024.10.4

### DIFF
--- a/dao/CHANGELOG.md
+++ b/dao/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog 刀 DAO
 # Day Ahead Optimizer
-## [V2024.10.2.dev_a]
-- For users with dc-coupled PV there is (after the optimum calculation) an extra graph (for each battery one) which shows the energybalance of the battery(ies).
+## [V2024.10.3]
+- There is an extra optionalgraph (for each battery one) which shows the energybalance of the battery(ies).
+You can omit this graph with a setting in the "graphics"-section": <br> 
+`"battery balance": "False",`
+- There was in the dasboard during an optimum calculation sometimes an **internal server error** caused by a too low timeout (30 sec).
+The new timeout is raised to 60 sec. 
+- When Nordpool data were not present there was a json-error message. This is corrected: there is now a not present message.
+- The Nordpool source didn't work ane more. The module with the api library for Nordpool is updated.
 
 ## [V2024.10.2]
 - New version of entsoe-py module fixed entsoe-issue

--- a/dao/CHANGELOG.md
+++ b/dao/CHANGELOG.md
@@ -11,7 +11,7 @@ You can omit this graph with a setting in the "graphics"-section": <br>
 - There was in the dasboard during an optimum calculation sometimes an **internal server error** caused by a too low timeout (30 sec).
 The new timeout is raised to 60 sec. 
 - When Nordpool data were not present there was a json-error message. This is corrected: there is now a not present message.
-- The Nordpool source didn't work ane more. The module with the api library for Nordpool is updated.
+- The Nordpool source didn't work anymore. The module with the api library for Nordpool is updated.
 
 
 ## [V2024.10.2]

--- a/dao/CHANGELOG.md
+++ b/dao/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog 刀 DAO
 # Day Ahead Optimizer
+## [V2024.10.2.dev_a]
+- For users with dc-coupled PV there is (after the optimum calculation) an extra graph (for each battery one) which shows the energybalance of the battery(ies).
+
 ## [V2024.10.2]
 - New version of entsoe-py module fixed entsoe-issue
 - New optional feature is introduced: "reduced hours". With this feature you can limit the max power

--- a/dao/CHANGELOG.md
+++ b/dao/CHANGELOG.md
@@ -8,6 +8,7 @@ You can omit this graph with a setting in the "graphics"-section": <br>
 The new timeout is raised to 60 sec. 
 - When Nordpool data were not present there was a json-error message. This is corrected: there is now a not present message.
 - The Nordpool source didn't work ane more. The module with the api library for Nordpool is updated.
+- When there are no batteries configured there was a soc-calculation error. This is corrected.
 
 ## [V2024.10.2]
 - New version of entsoe-py module fixed entsoe-issue

--- a/dao/CHANGELOG.md
+++ b/dao/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 刀 DAO
 # Day Ahead Optimizer
+## [V2024.10.4]
+- When there are no batteries configured there was a soc-calculation error. This is corrected.
+- The color of all the soc-lines are changed to "olive"
+
 ## [V2024.10.3]
 - There is an extra optionalgraph (for each battery one) which shows the energybalance of the battery(ies).
 You can omit this graph with a setting in the "graphics"-section": <br> 
@@ -8,7 +12,7 @@ You can omit this graph with a setting in the "graphics"-section": <br>
 The new timeout is raised to 60 sec. 
 - When Nordpool data were not present there was a json-error message. This is corrected: there is now a not present message.
 - The Nordpool source didn't work ane more. The module with the api library for Nordpool is updated.
-- When there are no batteries configured there was a soc-calculation error. This is corrected.
+
 
 ## [V2024.10.2]
 - New version of entsoe-py module fixed entsoe-issue

--- a/dao/DOCS.md
+++ b/dao/DOCS.md
@@ -562,145 +562,146 @@ Dit regelt de supervisor van Home Assistant dan voor je.
 
 ----------------------------
 
-| Key                      | Subkey                       | Type             | Default                            | Opmerkingen                                        |
-|--------------------------|------------------------------|------------------|------------------------------------|----------------------------------------------------|
-| **homeassistant**        | protocol api                 | string           | http                               | Alleen invullen                                    |
-|                          | ip adress                    | string           | supervisor                         | als addon op                                       |  
-|                          | ip port                      | integer          | blanco                             | andere machine                                     | 
-|                          | token                        | string           | blanco                             | draait                                             | 
-| **database ha**          | engine                       | string           | mysql                              | keuze uit: mysql / sqlite / postgresql             |
-|                          | server                       | string           | core-mariadb                       | default als addo met mysql als engine              |
-|                          | database                     | string           | homeassistant                      |                                                    |
-|                          | username                     | string           | homeassistant                      |                                                    |
-|                          | password                     | string           |                                    |                                                    |
-| **database da**          | engine                       | string           | mysql                              | keuze uit: mysql / sqlite / postgresql             |
-|                          | server                       | string           | core-mariadb                       | default als addon met mysql als engine             |
-|                          | database                     | string           | day_ahead                          |                                                    |
-|                          | username                     | string           | day_ahead                          |                                                    |
-|                          | password                     | string           |                                    |                                                    |
-| **meteoserver-key**      |                              | string           |                                    |                                                    |
-| **prices**               | source day ahead             | string           | nordpool                           | keuze uit: nordpool / entsoe / easyenergy / tibber |
-|                          | entsoe-api-key               | string           |                                    | alleen bij entsoe als source                       |
-|                          | regular high                 | getal            |                                    |                                                    |
-|                          | regular low                  | getal            |                                    |                                                    |
-|                          | switch to low                | integer          | 23                                 |                                                    |
-|                          | energy taxes delivery        | list             |                                    | {datum : getal}                                    |
-|                          | energy taxes redelivery      | list             |                                    | {datum : getal}                                    |
-|                          | cost supplier delivery       | list             |                                    | {datum : getal}                                    |
-|                          | cost supplier redelivery     | list             |                                    | {datum : getal}                                    |
-|                          | vat                          | list             |                                    | {datum : getal}                                    |
-|                          | last invoice                 | datum            |                                    | begindatum contract                                |
-|                          | tax refund                   | boolean          |                                    |                                                    |
-| **log level**            |                              | string           | "info"                             | keuze uit "debug", "info", "warning" of "error"    |
-| **use_calc_baseload**    |                              | boolean          | "False"                            |                                                    |
+| Key                       | Subkey                       | Type             | Default                            | Opmerkingen                                        |
+|---------------------------|------------------------------|------------------|------------------------------------|----------------------------------------------------|
+| **homeassistant**         | protocol api                 | string           | http                               | Alleen invullen                                    |
+|                           | ip adress                    | string           | supervisor                         | als addon op                                       |  
+|                           | ip port                      | integer          | blanco                             | andere machine                                     | 
+|                           | token                        | string           | blanco                             | draait                                             | 
+| **database ha**           | engine                       | string           | mysql                              | keuze uit: mysql / sqlite / postgresql             |
+|                           | server                       | string           | core-mariadb                       | default als addo met mysql als engine              |
+|                           | database                     | string           | homeassistant                      |                                                    |
+|                           | username                     | string           | homeassistant                      |                                                    |
+|                           | password                     | string           |                                    |                                                    |
+| **database da**           | engine                       | string           | mysql                              | keuze uit: mysql / sqlite / postgresql             |
+|                           | server                       | string           | core-mariadb                       | default als addon met mysql als engine             |
+|                           | database                     | string           | day_ahead                          |                                                    |
+|                           | username                     | string           | day_ahead                          |                                                    |
+|                           | password                     | string           |                                    |                                                    |
+| **meteoserver-key**       |                              | string           |                                    |                                                    |
+| **prices**                | source day ahead             | string           | nordpool                           | keuze uit: nordpool / entsoe / easyenergy / tibber |
+|                           | entsoe-api-key               | string           |                                    | alleen bij entsoe als source                       |
+|                           | regular high                 | getal            |                                    |                                                    |
+|                           | regular low                  | getal            |                                    |                                                    |
+|                           | switch to low                | integer          | 23                                 |                                                    |
+|                           | energy taxes delivery        | list             |                                    | {datum : getal}                                    |
+|                           | energy taxes redelivery      | list             |                                    | {datum : getal}                                    |
+|                           | cost supplier delivery       | list             |                                    | {datum : getal}                                    |
+|                           | cost supplier redelivery     | list             |                                    | {datum : getal}                                    |
+|                           | vat                          | list             |                                    | {datum : getal}                                    |
+|                           | last invoice                 | datum            |                                    | begindatum contract                                |
+|                           | tax refund                   | boolean          |                                    |                                                    |
+| **log level**             |                              | string           | "info"                             | keuze uit "debug", "info", "warning" of "error"    |
+| **use_calc_baseload**     |                              | boolean          | "False"                            |                                                    |
 | **baseload calc periode** |                              | getal            | 56                                 | alleen als "use_calc_baseload" = True              | 
-| **baseload**             |                              | list 24 getallen |                                    | alleen als "use_calc_baseload" = False             | 
-| **graphical backend**    |                              | string           | ""                                 |                                                    |
-| **graphics**             | style                        | string           | "default"                          | kies uit lijst                                     |
-|                          | prices delivery              | boolean          | "True"                             |                                                    |
-|                          | prices redelivery            | boolean          | "True"                             |                                                    |
-|                          | average delivery             | boolean          | "True"                             |                                                    |
-|                          | show                         | boolean          | "False"                            |                                                    |
-| **strategy**             |                              | string           | "minimize cost"                    | "minimize cost" of "minimize consumption"          |
-| **notifications**        | notification entity          | string           | ""                                 |                                                    | 
-|                          | opstarten                    | boolean          | "False"                            | 
-|                          | berekening                   | boolean          | "False"                            |                                                    | 
-|                          | last activity entity         | string           | ""                                 |                                                    | 
-| **grid**                 | max_power                    | getal            | 17                                 |                                                    | 
-| **history**              | save days                    | getal            | 7                                  |                                                    | 
-| **dashboard**            | port                         | getal            | 5000                               |                                                    | 
-| **boiler**               | boiler present               | boolean          | "False"                            |                                                    | 
-|                          | entity actual temp.          | string           |                                    |                                                    |
-|                          | entity setpoint              | string           |                                    |                                                    |
-|                          | entity hysterese             | string           |                                    |                                                    |
-|                          | cop                          | getal            |                                    | kWh/kWh                                            |
-|                          | cooling rate                 | getal            |                                    | K/h                                                |
-|                          | volume                       | getal            |                                    | liter                                              |
-|                          | heating allowed below        | getal            |                                    | °C                                                 |
-|                          | elec. power                  | getal            |                                    | W                                                  |
-|                          | activate service             | string           |                                    |                                                    |
-|                          | activate entity              | string           |                                    |                                                    |
-| **heating**              | heater present               | boolean          | "False"                            |                                                    | 
-|                          | degree days factor           | getal            |                                    | kWh/K.day                                          | 
-|                          | stages                       | list             |                                    | {max_power, cop}                                   | 
-|                          | ______max_power              | getal            |                                    | W                                                  | 
-|                          | ______cop                    | getal            |                                    | kWh/kWh                                            | 
-|                          | entity adjust heating curve  | string           |                                    | kWh/kWh                                            | 
-|                          | adjustment factor            | getal            |                                    | K                                                  | 
-| **battery**              |                              | list             |                                    | 0, 1 of meer {..}                                  | 
-|                          | name                         | string           |                                    |                                                    |
-|                          | name                         | string           |                                    |                                                    |
-|                          | entity actual level          | string           |                                    |                                                    |
-|                          | upper limit                  | getal            |                                    | %                                                  |
-|                          | lower limit                  | getal            |                                    | %                                                  |
-|                          | optimal lower level          | getal            |                                    | %                                                  |
-|                          | entity actual level          | string           |                                    |                                                    |
-|                          | entity min soc end opt       | string           | 0                                  |                                                    |
-|                          | entity max soc end opt       | string           | 100                                |                                                    |
-|                          | charge stages                | list             |                                    | {power, efficiency}                                | 
-|                          | ______power                  | getal            |                                    | W                                                  | 
-|                          | ______efficiency             | getal            |                                    | W/W (factor 0..1)                                  | 
-|                          | discharge stages             | list             |                                    | {power, efficiency}                                | 
-|                          | ______power                  | getal            |                                    | W                                                  | 
-|                          | ______efficiency             | getal            |                                    | W/W (factor 0..1)                                  | 
-|                          | reduced hours                | uur-waarde paren | {}                                 | W                                                  |
-|                          | minimum power                | getal            |                                    | W                                                  |
-|                          | dc_to_bat efficiency         | getal            |                                    | 0 .. 1.0                                           |
-|                          | dc_to_bat max power          | getal            | 2 x max power charge               | W                                                  |
-|                          | bat_to_dc efficiency         | getal            |                                    | 0 .. 1.0                                           |
-|                          | bat_to_dc max power          | getal            | 2 x max power discharge            | W                                                  |
-|                          | cycle cost                   | getal            |                                    | euro                                               |
-|                          | entity set power feedin      | string           |                                    | input_number                                       |
-|                          | entity stop inverter         | string           |                                    | input_datetime                                     |
-|                          | entity balance switch        | string           |                                    | input_boolean                                      |
-|                          | solar                        | list             |                                    | 0, 1 of meer {..} pv_dc, zie solar (pv_ac)         | 
-| **solar**                |                              | list             |                                    | 0, 1 of meer {..}  pv_ac                           | 
-|                          | name                         | string           |                                    |                                                    |
-|                          | tilt                         | getal            |                                    | helling 0 ..90                                     |
-|                          | orientation                  | getal            |                                    | -180(N) ..-90(W)..0(Z) ..90(W)..180(N)             |
-|                          | capacity                     | getal            |                                    | kWp                                                |
-|                          | yield                        | getal            |                                    | Wh/J/cm2                                           |
-|                          | entity pv switch             | string           | ""                                 | input_boolean                                      |
-| **electric vehicle**     |                              | list             |                                    | 0, 1 of meer {..}  electric vehicle                | 
-|                          | name                         | string           |                                    |                                                    |
-|                          | capacity                     | getal            |                                    | kWh                                                |
-|                          | entity position              | string           |                                    | tracker                                            |
-|                          | entity actual level          | string           |                                    |                                                    |
-|                          | entity plugged in            | string           |                                    | binary_sensor                                      |
-|                          | charging stages              | list             |                                    | 2 of meer {..}                                     | 
-|                          | ______ampere                 | getal            |                                    | A                                                  | 
-|                          | ______efficiency             | getal            | 1                                  | factor 0..1                                        | 
-|                          | charge three phase           | boolean          | true                               | true of false                                      |
-|                          | charge scheduler             |                  |                                    |                                                    |
-|                          | _____entity set level        | string           |                                    | input_number                                       |
-|                          | _____level margin            | getal            | 0                                  |                                                    |
-|                          | _____entity ready datetime   | string           |                                    | input_datetime                                     |
-|                          | entity set charging ampere   | string           |                                    | input_number                                       |
-|                          | charge switch                | string           |                                    | input_boolean                                      |
-|                          | entity stop laden            | string           | ""                                 | input_datetime                                     |
-| **machines**             |                              | list             |                                    | 0, 1 of meer {..}  pv_ac                           | 
-|                          | name                         | string           |                                    |                                                    |
-|                          | programs                     | list             |                                    | 1 of meer {..} progrma                             |
-|                          | _____name                    | string           |                                    |                                                    |
-|                          | _____power                   | list of numbers  |                                    | 0, 1 of meer numbers                               |
-|                          | entity start window          | string           |                                    | input_datetime, tijd                               |
-|                          | entity end window            | string           |                                    | input_datetime, tijd                               |
-|                          | entity selected program      | string           |                                    | input_select                                       |
-|                          | entity calculated start      | string           | ""                                 | input_datetime, datum en tijd                      |
-|                          | entity calculated end        | string           | ""                                 | input_datetime, datum en tijd                      |
-| **tibber**               | api url                      | string, url      | https://api.tibber.com/v1-beta/gql | desgewenst                                         | 
-|                          | api_token                    | string           |                                    |                                                    |
-| **report**               | entities grid consumption    | list of string   | []                                 |                                                    | 
-|                          | entities grid production     | list of string   | []                                 |                                                    | 
-|                          | entities solar production ac | list of string   | []                                 |                                                    | 
-|                          | entities solar production dc | list of string   | []                                 |                                                    | 
-|                          | entities ev consumption      | list of string   | []                                 |                                                    | 
-|                          | entities wp consumption      | list of string   | []                                 |                                                    | 
-|                          | entities boiler consumption  | list of string   | []                                 |                                                    | 
-|                          | entities battery consumption | list of string   | []                                 |                                                    | 
-|                          | entities battery production  | list of string   | []                                 |                                                    | 
-| **scheduler**            | active                       | boolean          | True                               | 
-|                          |                              | list             | {time, task}                       |                                        | 
+| **baseload**              |                              | list 24 getallen |                                    | alleen als "use_calc_baseload" = False             | 
+| **graphical backend**     |                              | string           | ""                                 |                                                    |
+| **graphics**              | style                        | string           | "default"                          | kies uit lijst                                     |
+|                           | battery balance              | boolean          | "True"                             |                                                    |
+|                           | prices delivery              | boolean          | "True"                             |                                                    |
+|                           | prices redelivery            | boolean          | "True"                             |                                                    |
+|                           | average delivery             | boolean          | "True"                             |                                                    |
+|                           | show                         | boolean          | "False"                            |                                                    |
+| **strategy**              |                              | string           | "minimize cost"                    | "minimize cost" of "minimize consumption"          |
+| **notifications**         | notification entity          | string           | ""                                 |                                                    | 
+|                           | opstarten                    | boolean          | "False"                            | 
+|                           | berekening                   | boolean          | "False"                            |                                                    | 
+|                           | last activity entity         | string           | ""                                 |                                                    | 
+| **grid**                  | max_power                    | getal            | 17                                 |                                                    | 
+| **history**               | save days                    | getal            | 7                                  |                                                    | 
+| **dashboard**             | port                         | getal            | 5000                               |                                                    | 
+| **boiler**                | boiler present               | boolean          | "False"                            |                                                    | 
+|                           | entity actual temp.          | string           |                                    |                                                    |
+|                           | entity setpoint              | string           |                                    |                                                    |
+|                           | entity hysterese             | string           |                                    |                                                    |
+|                           | cop                          | getal            |                                    | kWh/kWh                                            |
+|                           | cooling rate                 | getal            |                                    | K/h                                                |
+|                           | volume                       | getal            |                                    | liter                                              |
+|                           | heating allowed below        | getal            |                                    | °C                                                 |
+|                           | elec. power                  | getal            |                                    | W                                                  |
+|                           | activate service             | string           |                                    |                                                    |
+|                           | activate entity              | string           |                                    |                                                    |
+| **heating**               | heater present               | boolean          | "False"                            |                                                    | 
+|                           | degree days factor           | getal            |                                    | kWh/K.day                                          | 
+|                           | stages                       | list             |                                    | {max_power, cop}                                   | 
+|                           | ______max_power              | getal            |                                    | W                                                  | 
+|                           | ______cop                    | getal            |                                    | kWh/kWh                                            | 
+|                           | entity adjust heating curve  | string           |                                    | kWh/kWh                                            | 
+|                           | adjustment factor            | getal            |                                    | K                                                  | 
+| **battery**               |                              | list             |                                    | 0, 1 of meer {..}                                  | 
+|                           | name                         | string           |                                    |                                                    |
+|                           | name                         | string           |                                    |                                                    |
+|                           | entity actual level          | string           |                                    |                                                    |
+|                           | upper limit                  | getal            |                                    | %                                                  |
+|                           | lower limit                  | getal            |                                    | %                                                  |
+|                           | optimal lower level          | getal            |                                    | %                                                  |
+|                           | entity actual level          | string           |                                    |                                                    |
+|                           | entity min soc end opt       | string           | 0                                  |                                                    |
+|                           | entity max soc end opt       | string           | 100                                |                                                    |
+|                           | charge stages                | list             |                                    | {power, efficiency}                                | 
+|                           | ______power                  | getal            |                                    | W                                                  | 
+|                           | ______efficiency             | getal            |                                    | W/W (factor 0..1)                                  | 
+|                           | discharge stages             | list             |                                    | {power, efficiency}                                | 
+|                           | ______power                  | getal            |                                    | W                                                  | 
+|                           | ______efficiency             | getal            |                                    | W/W (factor 0..1)                                  | 
+|                           | reduced hours                | uur-waarde paren | {}                                 | W                                                  |
+|                           | minimum power                | getal            |                                    | W                                                  |
+|                           | dc_to_bat efficiency         | getal            |                                    | 0 .. 1.0                                           |
+|                           | dc_to_bat max power          | getal            | 2 x max power charge               | W                                                  |
+|                           | bat_to_dc efficiency         | getal            |                                    | 0 .. 1.0                                           |
+|                           | bat_to_dc max power          | getal            | 2 x max power discharge            | W                                                  |
+|                           | cycle cost                   | getal            |                                    | euro                                               |
+|                           | entity set power feedin      | string           |                                    | input_number                                       |
+|                           | entity stop inverter         | string           |                                    | input_datetime                                     |
+|                           | entity balance switch        | string           |                                    | input_boolean                                      |
+|                           | solar                        | list             |                                    | 0, 1 of meer {..} pv_dc, zie solar (pv_ac)         | 
+| **solar**                 |                              | list             |                                    | 0, 1 of meer {..}  pv_ac                           | 
+|                           | name                         | string           |                                    |                                                    |
+|                           | tilt                         | getal            |                                    | helling 0 ..90                                     |
+|                           | orientation                  | getal            |                                    | -180(N) ..-90(W)..0(Z) ..90(W)..180(N)             |
+|                           | capacity                     | getal            |                                    | kWp                                                |
+|                           | yield                        | getal            |                                    | Wh/J/cm2                                           |
+|                           | entity pv switch             | string           | ""                                 | input_boolean                                      |
+| **electric vehicle**      |                              | list             |                                    | 0, 1 of meer {..}  electric vehicle                | 
+|                           | name                         | string           |                                    |                                                    |
+|                           | capacity                     | getal            |                                    | kWh                                                |
+|                           | entity position              | string           |                                    | tracker                                            |
+|                           | entity actual level          | string           |                                    |                                                    |
+|                           | entity plugged in            | string           |                                    | binary_sensor                                      |
+|                           | charging stages              | list             |                                    | 2 of meer {..}                                     | 
+|                           | ______ampere                 | getal            |                                    | A                                                  | 
+|                           | ______efficiency             | getal            | 1                                  | factor 0..1                                        | 
+|                           | charge three phase           | boolean          | true                               | true of false                                      |
+|                           | charge scheduler             |                  |                                    |                                                    |
+|                           | _____entity set level        | string           |                                    | input_number                                       |
+|                           | _____level margin            | getal            | 0                                  |                                                    |
+|                           | _____entity ready datetime   | string           |                                    | input_datetime                                     |
+|                           | entity set charging ampere   | string           |                                    | input_number                                       |
+|                           | charge switch                | string           |                                    | input_boolean                                      |
+|                           | entity stop laden            | string           | ""                                 | input_datetime                                     |
+| **machines**              |                              | list             |                                    | 0, 1 of meer {..}  pv_ac                           | 
+|                           | name                         | string           |                                    |                                                    |
+|                           | programs                     | list             |                                    | 1 of meer {..} progrma                             |
+|                           | _____name                    | string           |                                    |                                                    |
+|                           | _____power                   | list of numbers  |                                    | 0, 1 of meer numbers                               |
+|                           | entity start window          | string           |                                    | input_datetime, tijd                               |
+|                           | entity end window            | string           |                                    | input_datetime, tijd                               |
+|                           | entity selected program      | string           |                                    | input_select                                       |
+|                           | entity calculated start      | string           | ""                                 | input_datetime, datum en tijd                      |
+|                           | entity calculated end        | string           | ""                                 | input_datetime, datum en tijd                      |
+| **tibber**                | api url                      | string, url      | https://api.tibber.com/v1-beta/gql | desgewenst                                         | 
+|                           | api_token                    | string           |                                    |                                                    |
+| **report**                | entities grid consumption    | list of string   | []                                 |                                                    | 
+|                           | entities grid production     | list of string   | []                                 |                                                    | 
+|                           | entities solar production ac | list of string   | []                                 |                                                    | 
+|                           | entities solar production dc | list of string   | []                                 |                                                    | 
+|                           | entities ev consumption      | list of string   | []                                 |                                                    | 
+|                           | entities wp consumption      | list of string   | []                                 |                                                    | 
+|                           | entities boiler consumption  | list of string   | []                                 |                                                    | 
+|                           | entities battery consumption | list of string   | []                                 |                                                    | 
+|                           | entities battery production  | list of string   | []                                 |                                                    | 
+| **scheduler**             | active                       | boolean          | True                               | 
+|                           |                              | list             | {time, task}                       |                                                    | 
  
 
 ### **homeassistant**<br>
@@ -969,8 +970,10 @@ Je hebt de keuze uit de volgende opties:
   
    Meer informatie:``https://matplotlib.org/stable/gallery/style_sheets/index.html```
 
-* show : "true" of "false", default "false" <br>
+* show: "true" of "false", default "false" <br>
  Als je deze op "true" zet wordt na het uitvoeren van de berekening direct de grafiek getoond.
+* battery balance: "True" of "False", default "True" <br>
+Deze optie bepaalt of je een grafiek van de energiebalans van je batterij(en) te zien krijgt.<br>
 
 Voor de lijngrafieken van de prijzen kun je met **True** of **False** kiezen welke je wil zien:
 * prices delivery: prijzen voor levering, default = True

--- a/dao/config.yaml
+++ b/dao/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: 刀 Day Ahead Optimizer
-version: "2024.10.2.dev_a"
+version: "2024.10.3"
 slug: day_ahead_opt
 description: Docker used by Home Assistant Community Add-ons for day ahead optimizations
 url: https://github.com/corneel27/day-ahead/

--- a/dao/config.yaml
+++ b/dao/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: 刀 Day Ahead Optimizer
-version: "2024.10.2"
+version: "2024.10.2.dev_a"
 slug: day_ahead_opt
 description: Docker used by Home Assistant Community Add-ons for day ahead optimizations
 url: https://github.com/corneel27/day-ahead/

--- a/dao/config.yaml
+++ b/dao/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: 刀 Day Ahead Optimizer
-version: "2024.10.3"
+version: "2024.10.4"
 slug: day_ahead_opt
 description: Docker used by Home Assistant Community Add-ons for day ahead optimizations
 url: https://github.com/corneel27/day-ahead/

--- a/dao/data/options_example.json
+++ b/dao/data/options_example.json
@@ -79,6 +79,7 @@
   "graphics": {
     "style": "dark_background",
     "show" : "true",
+    "battery balance": "True",
     "prices delivery": "True",
     "prices redelivery": "True",
     "average delivery": "True"

--- a/dao/prog/da_prices.py
+++ b/dao/prog/da_prices.py
@@ -119,7 +119,13 @@ class DaPrices:
                 end_date = None
             else:
                 end_date = start
-            hourly_prices_spot = prices_spot.hourly(areas=['NL'], end_date=end_date)
+            try:
+                hourly_prices_spot = prices_spot.hourly(areas=['NL'], end_date=end_date)
+            except Exception as ex:
+                # logging.error(ex)
+                logging.error(f"Geen data van Nordpool: tussen {start} en {end}")
+                return
+
             hourly_values = hourly_prices_spot['areas']['NL']['values']
             s = pp.pformat(hourly_values, indent=2)
             logging.info(f"Day ahead prijzen van Nordpool:\n {s}")

--- a/dao/prog/da_prices.py
+++ b/dao/prog/da_prices.py
@@ -111,6 +111,13 @@ class DaPrices:
                     df_db.loc[df_db.shape[0]] = [str(last_time), 'da', row[2] / 1000]
                 logging.debug(f"Day ahead prijzen (source: entsoe, db-records): \n{df_db.to_string(index=False)}")
                 self.db_da.savedata(df_db)
+                end_dt = datetime.datetime(end.year, end.month, end.day, 23)
+                last_time_dt = datetime.datetime.fromtimestamp(last_time)
+                if last_time_dt < end_dt:
+                    if len(df_db) == 0:
+                        logging.error(f"Geen data van Entsoe tot en met {end_dt}")
+                    else:
+                        logging.warning(f"Geen data van Entsoe tussen {last_time_dt} en {end_dt}")
 
         if source.lower() == "nordpool":
             # ophalen bij Nordpool

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -1877,7 +1877,8 @@ class DaCalc(DaBase):
         mach_n = []
         ev_n = []
         c_l_p = []
-        soc_p = []
+        soc = []
+        soc_b = []
         pv_p_org = []
         pv_p_opt = []
         pv_ac_p = []
@@ -1902,12 +1903,16 @@ class DaCalc(DaBase):
             accu_out_p.append(accu_out_sum * hour_fraction[u])
             max_y = max(max_y, (c_l_p[u] + pv_p_org[u] + pv_ac_p[u]), abs(
                 c_t_total[u].x) + b_l[u] + c_b[u].x + c_hp[u].x + c_ev_sum[u] + c_ma_sum[u] + accu_in_sum)
+            soc_t = list(df_soc["soc"])
             for b in range(B):
+                soc_b.append(list(df_soc["soc_"+str(b)]))
+            '''
                 if u == 0:
                     soc_p.append([])
                 soc_p[b].append(soc[b][u].x)
         for b in range(B):
             soc_p[b].append(soc[b][U].x)
+            '''
 
         # grafiek 1
         import numpy as np
@@ -2016,7 +2021,11 @@ class DaCalc(DaBase):
         pil_logger.setLevel(max(logging.INFO, self.log_level))
 
         plt.style.use(style)
-        fig, axis = plt.subplots(figsize=(8, 9), nrows=3)
+        nrows = 3
+        for b in range(B):
+            if pv_dc_num[b] > 0:
+                nrows += 1
+        fig, axis = plt.subplots(figsize=(8, 3 * nrows), nrows=nrows)
         ind = np.arange(U)
         axis[0].bar(ind, np.array(org_l), label='Levering', color='#00bfff', align="edge")
         if sum(pv_p_org) > 0:
@@ -2046,8 +2055,6 @@ class DaCalc(DaBase):
         axis[0].legend(loc='best', bbox_to_anchor=(1.05, 1.00))
         axis[0].set_ylabel('kWh')
         ylim = math.ceil(max_y)
-        # math.ceil(max(max(accu_out_p) + max(c_l_p) + max(pv_p), -min(min(base_n), min(boiler_n),
-        # min(heatpump_n), min(ev_n), min(c_t_n), min(accu_in_n) )))
         axis[0].set_ylim([-ylim, ylim])
         axis[0].set_xticks(ind, labels=uur)
         axis[0].xaxis.set_major_locator(ticker.MultipleLocator(2))
@@ -2090,27 +2097,82 @@ class DaCalc(DaBase):
         axis[1].set_xticks(ind, labels=uur)
         axis[1].xaxis.set_major_locator(ticker.MultipleLocator(2))
         axis[1].xaxis.set_minor_locator(ticker.MultipleLocator(1))
-        axis[1].set_title("Day Ahead geoptimaliseerd: " + strategie +
-                          ", winst € {:<0.2f}".format(old_cost_da - cost.x))
+        axis[1].set_title(f"Day Ahead geoptimaliseerd\nStrategie: {strategie}"
+                          f" winst € {(old_cost_da - cost.x):0.2f}")
         axis[1].sharex(axis[0])
 
+        gr_no = 1
+        for b in range(B):
+            if pv_dc_num[b] > 0:
+                # make graph of battery
+                gr_no += 1
+                ac_p = []
+                ac_n = []
+                pv_p = []
+                bat_p = []
+                bat_n = []
+                ind = np.arange(U+1)
+                uur.append(24)
+                for u in range(U):
+                    # model += (dc_from_ac[b][u] + dc_from_bat[b][u] + pv_prod_dc_sum[b][u] ==
+                    #           dc_to_ac[b][u] + dc_to_bat[b][u])
+                    ac_p.append(dc_from_ac[b][u].x)
+                    ac_n.append(-dc_to_ac[b][u].x)
+                    pv_p.append(pv_prod_dc_sum[b][u].x)
+                    bat_p.append(dc_from_bat[b][u].x)
+                    bat_n.append(-dc_to_bat[b][u].x)
+                # extra uur voor soc
+                ac_p.append(0)
+                ac_n.append(0)
+                pv_p.append(0)
+                bat_p.append(0)
+                bat_n.append(0)
+                legs = []
+                leg1 = axis[gr_no].bar(ind, np.array(ac_p), label='AC<->',
+                                       color='red', align="edge")
+                leg2 = axis[gr_no].bar(ind, np.array(bat_p), label='BAT<->',
+                                       bottom=np.array(ac_p),
+                                       color='blue', align="edge")
+                leg3 = axis[gr_no].bar(ind, np.array(pv_p), label='PV->',
+                                       bottom=np.array(ac_p) + np.array(bat_p),
+                                       color='lime', align="edge")
+                axis[gr_no].bar(ind, np.array(ac_n), color='red', align="edge")
+                axis[gr_no].bar(ind, np.array(bat_n),
+                                bottom=np.array(ac_n),
+                                color='blue', align="edge")
+                # axis[gr_no].legend(loc='best', bbox_to_anchor=(1.30, 1.00))
+                axis[gr_no].set_ylabel('kWh')
+                axis[gr_no].set_ylim([-ylim, ylim])
+                axis[gr_no].set_xticks(ind, labels=uur)
+                axis[gr_no].xaxis.set_major_locator(ticker.MultipleLocator(2))
+                axis[gr_no].xaxis.set_minor_locator(ticker.MultipleLocator(1))
+                axis[gr_no].set_title(f"Energiebelans per uur voor {self.battery_options[b]['name']}")
+                axis[gr_no].sharex(axis[0])
+                axis_20 = axis[gr_no].twinx()
+                leg4 = axis_20.plot(ind, soc_b[b], label='% SoC', linestyle="solid", color='blue')
+                axis_20.set_ylabel('% SoC')
+                axis_20.set_ylim([0, 100])
+                labels = ["AC<->", 'BAT<->', "PV->", '% SoC']
+                axis[gr_no].legend(labels=labels, loc='best', bbox_to_anchor=(1.35, 1.00))
+
+
+        gr_no += 1
         ln1 = []
         line_styles = ["solid", "dashed", "dotted"]
         ind = np.arange(U+1)
-        uur.append(24)
-        for b in range(B):
-            ln1.append(axis[2].plot(ind, soc_p[b], label='SoC ' + self.battery_options[b]["name"],
-                       linestyle=line_styles[b], color='red'))
-        axis[2].set_xticks(ind, labels=uur)
-        axis[2].set_ylabel('% SoC')
-        axis[2].set_xlabel("uren van de dag")
-        axis[2].xaxis.set_major_locator(ticker.MultipleLocator(2))
-        axis[2].xaxis.set_minor_locator(ticker.MultipleLocator(1))
-        axis[2].set_ylim([0, 100])
-        axis[2].set_title("Verloop SoC en tarieven")
-        axis[2].sharex(axis[0])
+        if len(uur) < U+1:
+            uur.append(24)
+        ln1.append(axis[gr_no].plot(ind, soc_t, label='SoC', linestyle=line_styles[0], color='red'))
+        axis[gr_no].set_xticks(ind, labels=uur)
+        axis[gr_no].set_ylabel('% SoC')
+        axis[gr_no].set_xlabel("uren van de dag")
+        axis[gr_no].xaxis.set_major_locator(ticker.MultipleLocator(2))
+        axis[gr_no].xaxis.set_minor_locator(ticker.MultipleLocator(1))
+        axis[gr_no].set_ylim([0, 100])
+        axis[gr_no].set_title("Verloop SoC en tarieven")
+        axis[gr_no].sharex(axis[0])
 
-        axis22 = axis[2].twinx()
+        axis22 = axis[gr_no].twinx()
         if self.config.get(["graphics", "prices delivery"], None, "true").lower() == "true":
             pl.append(pl[-1])
             ln2 = axis22.step(ind, np.array(pl), label='Tarief\nlevering', color='#00bfff', where='post')

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -2160,10 +2160,10 @@ class DaCalc(DaBase):
                 axis[gr_no].set_title(f"Energiebelans per uur voor {self.battery_options[b]['name']}")
                 axis[gr_no].sharex(axis[0])
                 axis_20 = axis[gr_no].twinx()
-                leg4 = axis_20.plot(ind, soc_b[b], label='% SoC', linestyle="solid", color='blue')
+                leg4 = axis_20.plot(ind, soc_b[b], label='% SoC', linestyle="solid", color='olive')
                 axis_20.set_ylabel('% SoC')
                 axis_20.set_ylim([0, 100])
-                soc_line = mlines.Line2D([], [], color='blue', label='SoC %')
+                soc_line = mlines.Line2D([], [], color='olive', label='SoC %')
                 if pv_dc_num[b] > 0:
                     labels = ["AC<->", 'BAT<->', "PV->", '% SoC']
                     handles =[leg1, leg2, leg3, soc_line]
@@ -2180,7 +2180,7 @@ class DaCalc(DaBase):
         if len(uur) < U+1:
             uur.append(24)
         if B > 0:
-            ln1.append(axis[gr_no].plot(ind, soc_t, label='SoC', linestyle=line_styles[0], color='red'))
+            ln1.append(axis[gr_no].plot(ind, soc_t, label='SoC', linestyle=line_styles[0], color='olive'))
         axis[gr_no].set_xticks(ind, labels=uur)
         axis[gr_no].set_ylabel('% SoC')
         axis[gr_no].set_xlabel("uren van de dag")

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -2157,7 +2157,7 @@ class DaCalc(DaBase):
                 axis[gr_no].set_xticks(ind, labels=uur)
                 axis[gr_no].xaxis.set_major_locator(ticker.MultipleLocator(2))
                 axis[gr_no].xaxis.set_minor_locator(ticker.MultipleLocator(1))
-                axis[gr_no].set_title(f"Energiebelans per uur voor {self.battery_options[b]['name']}")
+                axis[gr_no].set_title(f"Energiebalans per uur voor {self.battery_options[b]['name']}")
                 axis[gr_no].sharex(axis[0])
                 axis_20 = axis[gr_no].twinx()
                 leg4 = axis_20.plot(ind, soc_b[b], label='% SoC', linestyle="solid", color='olive')

--- a/dao/requirements.txt
+++ b/dao/requirements.txt
@@ -8,7 +8,7 @@ mysql-connector-python~=9.0.0
 hassapi~=0.2.1
 mip~=1.16rc0
 python-dateutil~=2.8.2
-nordpool~=0.3.3
+nordpool~=0.4.1
 entsoe-py~=0.6.11
 beautifulsoup4
 sqlalchemy

--- a/dao/requirements.txt
+++ b/dao/requirements.txt
@@ -7,7 +7,7 @@ mysql~=0.0.3
 mysql-connector-python~=9.0.0
 hassapi~=0.2.1
 mip~=1.16rc0
-python-dateutil~=2.8.2
+python-dateutil~=2.9.0.post0
 nordpool~=0.4.1
 entsoe-py~=0.6.11
 beautifulsoup4

--- a/dao/webserver/gunicorn_config.py
+++ b/dao/webserver/gunicorn_config.py
@@ -7,3 +7,4 @@ workers = 2
 bind = f"0.0.0.0:{port}"
 forwarded_allow_ips = '*'
 secure_scheme_headers = {'X-Forwarded-Proto': 'https'}
+timeout = 60


### PR DESCRIPTION
- When there are no batteries configured there was a soc-calculation error. This is corrected.
- The color of all the soc-lines are changed to "olive"
- There is an extra optionalgraph (for each battery one) which shows the energybalance of the battery(ies).
You can omit this graph with a setting in the "graphics"-section": `"battery balance": "False",`
- There was in the dasboard during an optimum calculation sometimes an **internal server error** caused by a too low timeout (30 sec).
The new timeout is raised to 60 sec. 
- When Nordpool data were not present there was a json-error message. This is corrected: there is now a not present message.
- The Nordpool source didn't work anymore. The module with the api library for Nordpool is updated.
