### PR TITLE
Versioned releases

### DIFF
--- a/.github/workflows/create_new_release.yaml
+++ b/.github/workflows/create_new_release.yaml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'dao/config.yaml'
+
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create new release
+    runs-on: ubuntu-latest
+    steps:
+      # checkout the repo
+      - name: Checkout the repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      # extract version from dao/config.yaml
+      - name: Get version number
+        run: |
+          VERSION=$(grep version dao/config.yaml | sed -e 's/^version: //')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          if [[ $VERSION == *".rc"* ]]; then
+            echo "LATEST=false" >> $GITHUB_ENV;
+          else
+            echo "LATEST=true" >> $GITHUB_ENV;
+          fi
+
+      # create a new release for $VERSION
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${VERSION}" \
+              --repo="${GITHUB_REPOSITORY}" \
+              --title="${VERSION}" \
+              -d --generate-notes --latest=${LATEST}
+

--- a/.github/workflows/publish_or_test_containers.yaml
+++ b/.github/workflows/publish_or_test_containers.yaml
@@ -35,8 +35,8 @@ jobs:
       - name: Update version when release
         if: ${{ github.event_name == 'release' }}
         run: |
-          sed -ie 's/^version: .*/version: ${{ github.ref_name }}/g' dao/config.yaml
-          echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+          VERSION=$(grep version dao/config.yaml | sed -e 's/^version: //')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       # Add additional 'stable' tag when this is a non-rc release
       - name: Set stable on a verions without .rc
@@ -115,7 +115,7 @@ jobs:
             ${{ env.EXTRA_TAG }} \
             --generic $VERSION \
             --${{ matrix.arch }} \
-            --image "dao-${{ matrix.arch }}-addon" \
+            --image "dao-${{ matrix.arch }}" \
             --target dao \
             --docker-hub ghcr.io/${ACTOR} \
             --version $VERSION 


### PR DESCRIPTION
The previous workflow did not take into account that the hass addon store uses the config.yaml file for versioning.
This is fixed by introducing a seperate workflow:

* When creating a new release, a change (of `version`) in `config.yaml` is pushed to the main branch. This change is detected by create_new_release.yaml and a new draft release is created for the version that is in `config.yaml`
* When the draft release is puslished (either as RC or as release), publish_or_test_containers.yaml picks this up and builds all relevant genereic and addon containers.
