### PR TITLE
add python ecosystem to dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,4 +5,7 @@ updates:
     schedule:
       interval: weekly
       time: "06:00"
-
+  - package-ecosystem: pip
+    directory: "/dao"
+    schedule:
+      interval: daily


### PR DESCRIPTION
We can try to have dependabot automatically update our python requirements.txt. If this is too unstable, we can always remove it.