### PR TITLE
Update check_db.py - Timezone check

### DIFF
--- a/dao/prog/check_db.py
+++ b/dao/prog/check_db.py
@@ -279,10 +279,11 @@ class CheckDB:
                 timezone = tzlocal.get_localzone_name()
                 statement = text("SHOW TIMEZONE;")
                 result = con.execute(statement)
-                tz_db = result.first()[0]
+                row = result.first()
+                tz_db = row[0]
                 if tz_db != timezone:
-                    print(f'De timezone van de database "day_ahead" {result} wijkt af van local timezone: {timezone}')
-                    print("Update de timezone (zie DOCS.md")
+                    print(f'De timezone van de database "day_ahead" is "{tz_db}" en wijkt af van local timezone: {timezone}')
+                    print("Update de timezone (zie DOCS.md)")
 
         if l_version < n_version:
             # update version number database


### PR DESCRIPTION
De nieuwe timezone check voor postgresql klopte niet helemaal: `De timezone van de database "day_ahead" <sqlalchemy.engine.cursor.CursorResult object at 0x7f570b7d4fa0> wijkt af van local timezone: Europe/Amsterdam`

Deze aanpassing resulteert in:
`De timezone van de database "day_ahead" is Etc/UTC en wijkt af van local timezone: Europe/Amsterdam`