### PR TITLE
Fix error get_meteo when solar is configured with strings

### DIFF
--- a/dao/prog/da_meteo.py
+++ b/dao/prog/da_meteo.py
@@ -232,16 +232,20 @@ class Meteo:
         solar = None
         if len(self.solar) > 0:
             solar = self.solar[0]
+            if "strings" in solar:
+                solar = solar["strings"][0]
         else:
             for b in range(len(self.bat)):
                 if len(self.bat[b]["solar"]) > 0:
                     solar = self.bat[b]["solar"][0]
-        if not (solar is None):
-            tilt = solar["tilt"]
-            orientation = solar["orientation"]
-        else:
+                    if "strings" in solar:
+                        solar = solar["strings"][0]
+        if solar is None:
             tilt = 45
             orientation = 0
+        else:
+            tilt = solar["tilt"]
+            orientation = solar["orientation"]
         tilt = min(90, max(0, tilt))
         hcol = math.radians(tilt)
         acol = math.radians(orientation)

--- a/release-testing/CHANGELOG.md
+++ b/release-testing/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog 刀 DAO
 # Day Ahead Optimizer
 
+# 2025.7.1.rc2
+Fixed error get_meteo when solar is configured with strings (reported by @Mirabis)
+
 # 2025.7.1.rc1
 
 Introduction for support of more strings in pv-inverters.<br>

--- a/release-testing/config.yaml
+++ b/release-testing/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: 刀 Day Ahead Optimizer (TESTING)
-version: 2025.7.1.rc1
+version: 2025.7.1.rc2
 stage: experimental
 slug: day_ahead_opt-testing
 description: Beta version of DAO. Use only for testing!


### PR DESCRIPTION
Fixed error get_meteo when solar is configured with strings (reported by @Mirabis)