### PR TITLE
2025.9.1.rc7

### DIFF
--- a/dao/requirements.txt
+++ b/dao/requirements.txt
@@ -19,5 +19,5 @@ mariadb~=1.1.13
 flask~=3.1.2
 ephem~=4.2
 gunicorn~=23.0.0
-cryptography~=46.0.1
+cryptography~=45.0.7
 tzlocal~=5.3.1

--- a/release-testing/CHANGELOG.md
+++ b/release-testing/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog 刀 DAO
 # Day Ahead Optimizer
+# 2025.9.1.rc7
+- Fix error (Signal SIGSEGV caught) in rc6 on x86 (arch=amd64) machines
+
 # 2025.9.1.rc6
 - Maximised the calculationtime to 20 sec, the accuracy to 0.005 euro (whichever comes first)
 - Fixed issues with boiler with 15min-interval

--- a/release-testing/config.yaml
+++ b/release-testing/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: 刀 Day Ahead Optimizer (TESTING)
-version: 2025.9.1.rc6
+version: 2025.9.1.rc7
 stage: experimental
 slug: day_ahead_opt-testing
 description: Beta version of DAO. Use only for testing!


### PR DESCRIPTION
2025.9.1.rc7
Fix error (Signal SIGSEGV caught) in rc6 on x86 (aarch=amd64) machines
Downgrade cryptography to 45.0.7