### PR TITLE
Make sure to exit the script on any error

### DIFF
--- a/dao/prog/build_miplib.sh
+++ b/dao/prog/build_miplib.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 if [ -d ""~/build"" ]; then rm -rf ~/build; fi
 mkdir -p ~/build
 cd ~/build


### PR DESCRIPTION
When the compile failed halfway, the lib directory is left in a half compiled state and was copied over to the final destination.

By exitting on any error we prevent this from happening.