### PR TITLE
Move the mip install to requirements

### DIFF
--- a/dao/Dockerfile
+++ b/dao/Dockerfile
@@ -55,7 +55,6 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY requirements.txt /tmp/
 RUN pip3 install uv
 RUN uv pip install -r /tmp/requirements.txt
-RUN pip install mip==1.16rc0 --ignore-requires-python
 
 COPY run /root/dao/prog/
 

--- a/dao/requirements.txt
+++ b/dao/requirements.txt
@@ -21,3 +21,4 @@ ephem~=4.2
 gunicorn~=23.0.0
 cryptography~=46.0.2
 tzlocal~=5.3.1
+mip==1.16rc0


### PR DESCRIPTION
Use this to make the python-mip module installation identical to other module installations.