### PR TITLE
Fix aarch64 build

### DIFF
--- a/.github/workflows/test_build.yaml
+++ b/.github/workflows/test_build.yaml
@@ -15,7 +15,7 @@ jobs:
         # we only test build release-testing for amd64
         # this can be changed if desired
         release: [ "testing" ]
-        arch: [ "amd64" ]
+        arch: [ "amd64", "aarch64" ]
     permissions:
       contents: read
       packages: write

--- a/dao/Dockerfile
+++ b/dao/Dockerfile
@@ -54,6 +54,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 COPY requirements.txt /tmp/
 RUN pip3 install uv
+RUN if [ "x${BUILD_ARCH}" = "xaarch64" ]; then ln -s `which mariadb_config` /usr/local/bin/mariadb_config; fi
 RUN uv pip install -r /tmp/requirements.txt
 
 COPY run /root/dao/prog/

--- a/dao/build.yaml
+++ b/dao/build.yaml
@@ -1,6 +1,6 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:8.0.0
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:8.1.3
   amd64: ghcr.io/hassio-addons/debian-base/amd64:8.1.3
 
 


### PR DESCRIPTION
Somehow mariadb on aarch64 tries to use /usr/local/bin, instead of /usr/bin.
Simply symlinked that binary fixes the build for now.
 
Also to catch things earlier we add aarch64 to the test builds together with amd64, even though is is significantly slower.