### PR TITLE
Fix build_mips.sh checks

### DIFF
--- a/dao/prog/build_miplib.sh
+++ b/dao/prog/build_miplib.sh
@@ -1,19 +1,40 @@
 #!/bin/bash
 set -e
 
-if [ -d ""~/build"" ]; then rm -rf ~/build; fi
+MARCH="-march=native"
+EXTRAFLAGS="--with-gcc-arch=native"
+if [ "$1" == "generic" ]; then
+  MARCH=""
+  EXTRAFLAGS=""
+fi
+[ ! -z $MARCH ] && echo "Compiling for native cpu!! This library will not be portable to other cpu's!!!" || true
+
+CXXFLAGS="${MARCH} -O3"
+
+if [ -d ~/build ]; then rm -rf ~/build; fi
 mkdir -p ~/build
 cd ~/build
 
-wget -nH https://raw.githubusercontent.com/coin-or/coinbrew/master/coinbrew
+wget -qnH https://raw.githubusercontent.com/coin-or/coinbrew/master/coinbrew
 chmod +x coinbrew
 
-./coinbrew build Cbc@master ADD_CXXFLAGS="-march=native -O3" --no-prompt --prefix=prog/ --tests=none --enable-cbc-parallel --enable-relocatable --no-third-party --with-gcc-arch=native
+./coinbrew build Cbc@master ADD_CXXFLAGS="${CXXFLAGS}" --no-prompt --prefix=prog/ --tests=none --enable-cbc-parallel --enable-relocatable --no-third-party ${EXTRAFLAGS=}
 
-if [ -d "/root/dao/prog/miplib/lib" ]; then rm -rf /root/dao/prog/miplib/lib; fi
+echo
+echo "Compilation finished! Moving lib into place."
+
+if [ -d /root/dao/prog/miplib/lib ]; then rm -rf /root/dao/prog/miplib/lib; fi
 mkdir -p /root/dao/prog/miplib/lib
 cp -a ~/build/prog/lib/*.so* /root/dao/prog/miplib/lib
 
-if [ -d "/config/miplib/lib" ]; then rm -rf /config/miplib/lib; fi
+if [ -d /config/miplib/lib ]; then
+  echo "Backing up the previously compiled libraries."
+  rm -rf /config/miplib/lib.bck;
+  mv /config/miplib/lib /config/miplib/lib.bck;
+fi
 mkdir -p /config/miplib/lib
 cp -a ~/build/prog/lib/*.so* /config/miplib/lib
+
+echo
+echo "All done!"
+


### PR DESCRIPTION
Fix some directory checks. Strings are not directories.
Also built in an automatic backup of previously compiled libs.

Enhanced the script to also allow building generic libraries by adding the "generic" argument when building (ie. `bash build_mips.sh generic`)