### PR TITLE
add wait at end of compile

### DIFF
--- a/dao/prog/build_miplib.sh
+++ b/dao/prog/build_miplib.sh
@@ -36,5 +36,6 @@ mkdir -p /config/miplib/lib
 cp -a ~/build/prog/lib/*.so* /config/miplib/lib
 
 echo
-echo "All done!"
+echo "All done. Hit any key to exit... (15 minutes timeout)"
+read -s -n 1 -t 900 || true && echo All done, exiting
 


### PR DESCRIPTION
This makes it easier to automate the compile, without the container continuesly rebooting when run as entrypoint with
--entrypoint=/root/dao/prog/build_miplib.sh

This is required for remote deployments that cannot enter containers directly and compile.