### PR TITLE
Fixes #199  - Add network capabilities to apparmor configuration

### DIFF
--- a/dao/apparmor.txt
+++ b/dao/apparmor.txt
@@ -5,6 +5,8 @@ profile day_ahead_opt flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   # Capabilities
+  network,
+  deny network raw,
   file,
   signal (send) set=(kill,term,int,hup,cont),
 


### PR DESCRIPTION
Bedankt voor je mooie add-on. Ik liep zelf ook tegen het probleem dat de addon niet correct start op HA Supervisor. Dit blijkt een AppArmor configuratie probleem te zijn. De AppArmor configuratie was niet compleet voor de permissie om een poort te openen. Bij deze opgelost.

Fixes #199 