### PR TITLE
Refactor notifcations in day-ahead

### DIFF
--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -131,12 +131,7 @@ class DaCalc(DaBase):
                 f"(meteo en/of dynamische prijzen) "
                 f"er kan niet worden gerekend"
             )
-            if self.notification_entity is not None:
-                self.set_value(
-                    self.notification_entity,
-                    f"Er ontbreken voor een aantal uur gegevens; "
-                    f"er kan niet worden gerekend",
-                )
+            self.notify("Er ontbreken voor een aantal uur gegevens; er kan niet worden gerekend")
             return
         if u_data <= 8 or u_prices <= 8:
             logging.warning(
@@ -144,17 +139,9 @@ class DaCalc(DaBase):
                 f"(en/of dynamische prijzen)\n"
                 f"controleer of alle gegevens zijn opgehaald"
             )
-            if self.notification_entity is not None:
-                self.set_value(
-                    self.notification_entity,
-                    f"Er ontbreken voor een aantal uur gegevens",
-                )
+            self.notify("Er ontbreken voor een aantal uur gegevens")
 
-        if self.notification_entity is not None and self.notification_berekening:
-            self.set_value(
-                self.notification_entity,
-                "DAO calc gestart " + dt.datetime.now().strftime("%d-%m-%Y %H:%M:%S"),
-            )
+        self.notify("DAO calc gestart")
 
         prog_data = prog_data.reset_index(drop=True)
         price_data = price_data.reset_index(drop=True)
@@ -4015,17 +4002,22 @@ class DaCalc(DaBase):
         if show_graph:
             plt.show()
         plt.close("all")
-
-        if self.notification_entity is not None and self.notification_berekening:
-            self.set_value(
-                self.notification_entity,
-                "DAO calc afgerond " + dt.datetime.now().strftime("%d-%m-%Y %H:%M:%S"),
-            )
+        self.notify("DAO calc afgerond", self.notification_berekening)
     
 
     def calc_optimum_debug(self):
         self.debug = True
         self.calc_optimum()
+
+    def notify(self, message,notification_berekening == True):
+        """
+        send notification
+        """
+        if self.notification_entity is not None and notification_berekening:
+            self.set_value(
+                self.notification_entity,
+                message + " " + dt.datetime.now().strftime("%d-%m-%Y %H:%M:%S"),
+            )
 
 
 def main():


### PR DESCRIPTION
next step could be to add run status numbers, such as 
101 = run started
102 = run finished
201 = missing meteo
202 = missing price data
203 = whatever error

We could send this to a separate HA enity to separate the textual error and the actual status