### PR TITLE
Fix: Open footer links in new tab for HA ingress compatibility

### DIFF
--- a/dao/webserver/app/templates/base.html
+++ b/dao/webserver/app/templates/base.html
@@ -65,8 +65,8 @@
     {% block content %}{% endblock %}
     </div>
   <footer>
-      <span style="float:right;"><a href="http://www.apache.org/licenses/LICENSE-2.0">&nbsp&copy;&nbsp{{ version[0:4] }}: Apache 2.0</a></span>
-      <span>&nbsp <a href="https://github.com/corneel27/day-ahead">Day Ahead Optimizer version: {{ version }}</a></span>&nbsp
+      <span style="float:right;"><a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">&nbsp&copy;&nbsp{{ version[0:4] }}: Apache 2.0</a></span>
+      <span>&nbsp <a href="https://github.com/corneel27/day-ahead" target="_blank">Day Ahead Optimizer version: {{ version }}</a></span>&nbsp
   </footer>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- Add `target="_blank"` to the Apache license and GitHub repository links in the footer of `base.html`
- This fixes the links breaking when the web UI is rendered inside Home Assistant's ingress iframe (browsers block navigation to sites like github.com within iframes due to X-Frame-Options)
- Upgrade the Apache license URL from HTTP to HTTPS