### PR TITLE
Add datetime picker

### DIFF
--- a/dao/webserver/app/__init__.py
+++ b/dao/webserver/app/__init__.py
@@ -3,6 +3,7 @@ from flask import Flask
 # sys.path.append("../")
 
 app = Flask(__name__)
+app.secret_key = 'secret_cookie_key' 
 
 from dao.webserver.app.routes import *
 

--- a/dao/webserver/app/routes.py
+++ b/dao/webserver/app/routes.py
@@ -1,5 +1,6 @@
 import collections
 import datetime
+import re
 
 # from sqlalchemy.sql.coercions import expect_col_expression_collection
 
@@ -275,16 +276,30 @@ bewerkingen = {
 
 def get_file_list(path: str, pattern: str) -> list:
     """
-    get a time-ordered file list with name and modified time
+    get a time-ordered file list with name and timestamp from filename
     :parameter path: folder
     :parameter pattern: wildcards to search for
     """
     flist = []
     for f in os.listdir(path):
         if fnmatch.fnmatch(f, pattern):
-            fullname = os.path.join(path, f)
-            flist.append({"name": f, "time": os.path.getmtime(fullname)})
-            # print(f, time.ctime(os.path.getmtime(f)))
+            # Extract timestamp from filename (e.g. calc_2026-02-17__08-45.png) because datetime picker works with
+            # absolut timestamps and then file modification date might differ from the timestamp in the filename, which is the intended reference time for the user  
+            m = re.search(r'(\d{4}-\d{2}-\d{2})__(\d{2})(:|\-)(\d{2})', f)
+            if m:
+                try:
+                    dt_str = f"{m.group(1)} {m.group(2)}:{m.group(4)}"
+                    dt = datetime.datetime.strptime(dt_str, "%Y-%m-%d %H:%M")
+                    timestamp = dt.timestamp()  # Local time as epoch
+                    flist.append({"name": f, "time": timestamp})
+                except (ValueError, OSError):
+                    # Fallback to mtime if filename parsing fails
+                    fullname = os.path.join(path, f)
+                    flist.append({"name": f, "time": os.path.getmtime(fullname)})
+            else:
+                # Fallback to mtime if no timestamp in filename
+                fullname = os.path.join(path, f)
+                flist.append({"name": f, "time": os.path.getmtime(fullname)})
     flist.sort(key=lambda x: x.get("time"), reverse=True)
     return flist
 
@@ -421,7 +436,7 @@ def home():
 
     if len(flist) > 0:
         # print('Active index:', index )
-        # print('Flist[',index,']:',time.ctime(flist[index]["time"]))
+        # print(flist[index]["name"], datetime.datetime.fromtimestamp(flist[index]["time"]))
         active_time = str(flist[index]["time"])
         if active_view == "grafiek":
             image = os.path.join(web_datapath + active_map, flist[index]["name"])
@@ -438,6 +453,10 @@ def home():
 # Remember this active time in global variable
     previous_time = active_time
 
+    flatpickr_times = [datetime.datetime.fromtimestamp(f["time"]).strftime('%Y-%m-%d %H:%M') for f in flist]
+    flatpickr_default_ts = float(active_time) if active_time else None
+    flatpickr_default = datetime.datetime.fromtimestamp(float(active_time)).strftime('%Y-%m-%d %H:%M') if active_time else ''
+
     return render_template(
         "home.html",
         title="Optimization",
@@ -450,6 +469,9 @@ def home():
         image=image,
         tabel=tabel,
         active_time=active_time,
+        flatpickr_times=flatpickr_times,
+        flatpickr_default_ts=flatpickr_default_ts,
+        flatpickr_default=flatpickr_default,
         version=__version__,
     )
 

--- a/dao/webserver/app/routes.py
+++ b/dao/webserver/app/routes.py
@@ -2,10 +2,11 @@ import collections
 import datetime
 import re
 
+
 # from sqlalchemy.sql.coercions import expect_col_expression_collection
 
 from dao.webserver.app import app
-from flask import render_template, request
+from flask import render_template, request, session as flask_session
 import fnmatch
 import os
 from subprocess import PIPE, run
@@ -346,11 +347,14 @@ def home():
     cur_subject = "grid"
     active_subject = "grid"
     cur_view = "grafiek"
-    global active_view 
+    #global active_view 
     global previous_time
     active_time = None
     action = None
     confirm_delete = False
+    #get active_view from session if available, otherwise use the default value; 
+    #this is to enable switching between grafiek and tabel while retaining the active time  
+    active_view = flask_session.get('active_view', 'grafiek')
 
     if config is not None:
         battery_options = config.battery
@@ -370,10 +374,11 @@ def home():
             active_subject = lst["subject"][0]
         if "view" in lst:
             active_view = lst["view"][0]
+            flask_session['active_view'] = active_view #update session with the new active_view
         if "active_time" in lst:
-            # Ignore active_time from POST if switching between grafiek & table; keep the active_time from the previous call
+            # Ignore active_time from POST if switching between grafiek & table; keep the active_time from the previous call from session.
             if cur_view != active_view:
-                active_time = previous_time
+                active_time = flask_session.get('active_time')
             else:
                 active_time = float(lst["active_time"][0])
         if "action" in lst:
@@ -405,7 +410,9 @@ def home():
             if abs(flist[i]["time"] - active_time) < diff_time:
                 diff_time = abs(flist[i]["time"] - active_time)
                 index = i
-        
+    # Ensure index is within valid range
+    index = max(0, min(index, len(flist) - 1))
+
     if action == "first":
         index = 0
     if action == "previous":
@@ -451,7 +458,8 @@ def home():
         tabel = None
         
 # Remember this active time in global variable
-    previous_time = active_time
+    #previous_time = active_time
+    flask_session['active_time'] = active_time #Store active_time in session to enable switching between grafiek and tabel while retaining the active time  
 
     flatpickr_times = [datetime.datetime.fromtimestamp(f["time"]).strftime('%Y-%m-%d %H:%M') for f in flist]
     flatpickr_default_ts = float(active_time) if active_time else None

--- a/dao/webserver/app/templates/home.html
+++ b/dao/webserver/app/templates/home.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% block selectie %}
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
 <script>
   function confirmation(){
     var result = confirm("Wil je dit verwijderen?");
@@ -10,7 +12,71 @@
     else {
       return false;
     }
-}
+  }
+  
+  function onDateChange(selectedDates) {
+    // User just closed the picker; they still need to click Apply
+  }
+    
+  document.addEventListener('DOMContentLoaded', function() {
+    // Parse available datetime strings (already formatted as Y-m-d H:i)
+    var availableTimes = {{ flatpickr_times | tojson }};
+    var defaultTimeTs = {{ flatpickr_default_ts | tojson }};
+    var defaultDateStr = "{{ flatpickr_default }}";
+    
+    // Convert datetime strings to Date objects to only show available options in the picker  
+    var enableDates = availableTimes.map(function(dateStr) {
+      return new Date(dateStr.replace(' ', 'T'));  // Parse ISO format
+    });
+    
+    flatpickr("#datetime_picker", {
+      enableTime: true,
+      dateFormat: "Y-m-d H:i",
+      time_24hr: true,
+      minuteIncrement: 15,
+      onClose: onDateChange,
+      minDate: new Date(Math.min(...enableDates.map(dateStr => new Date(dateStr)))), // Set minDate to the earliest available datetime  
+      maxDate: new Date(Math.max(...enableDates.map(dateStr => new Date(dateStr)))), // Set maxDate to the latest available datetime     
+      defaultDate: defaultDateStr || null, //set default so it matches the current active_time, or null if no active time
+      onBlur: function(selectedDates, dateStr, instance) {
+        // Prevent reverting when blurring away from picker
+        if (instance.selectedDates.length === 0 && defaultDateStr) {
+          instance.setDate(defaultDateStr, false);
+        }
+      },
+      onReady: function(selectedDates, dateStr, instance) {
+        // Add buttons to the calendar container
+        var calendarContainer = instance.calendarContainer;
+        var buttonContainer = document.createElement('div');
+        buttonContainer.style.cssText = 'display: flex; justify-content: center; gap: 10px; padding: 10px; border-top: 1px solid #e5e5e5;';
+        
+        var clearButton = document.createElement('button');
+        clearButton.textContent = 'Clear';
+        clearButton.style.cssText = 'background: #f8f8f8; color: #292a2e; border: 1px solid #ddd; padding: 5px 15px; border-radius: 4px; cursor: pointer;';
+        clearButton.onclick = function() {
+          instance.clear();
+          instance.close();
+        };
+        
+        var applyButton = document.createElement('button');
+        applyButton.textContent = 'Apply';
+        applyButton.style.cssText = 'background: #569ff7; color: #fff; border: none; padding: 5px 15px; border-radius: 4px; cursor: pointer;';
+        applyButton.onclick = function() {
+          if (instance.selectedDates.length > 0) {
+            // Get UTC timestamp from selected Date object
+            var selectedDate = instance.selectedDates[0];
+            var utcTimestamp = Math.floor(selectedDate.getTime() / 1000);
+            $('#active_time').val(utcTimestamp);
+            $("#content_form").submit();
+          }
+        };
+        
+        buttonContainer.appendChild(clearButton);
+        buttonContainer.appendChild(applyButton);
+        calendarContainer.appendChild(buttonContainer);
+      }
+    });
+  });
 </script>
 <form method="post" id="content_form">
 <div class="selector-container">
@@ -56,13 +122,14 @@
       <button name="action" class="btn btn_mid" value="fast_forward" title="-6 uur">
         <img src="static/frev.png" alt="prev" border="0" style="display:inline-block; height:1.5em; width:auto;" />
       </button>
-	  <button name="action" class="btn btn_mid" value="next">
+      <button name="action" class="btn btn_mid" value="next">
         <img src="static/next.png" alt="prev" border="0" style="display:inline-block; height:1.5em; width:auto;" />
       </button>
+      <input type="text" id="datetime_picker" placeholder="Select datetime" value="{{ flatpickr_default }}" style="height: 1em; padding: 0.25em; min-width: 110px; max-width: 160px;">
       <button name="action" class="btn btn_mid" value="previous">
         <img src="static/prev.png" alt="next" border="0" style="display:inline-block; height:1.5em; width:auto;" />
       </button>
-	  <button name="action" class="btn btn_mid" value="fast_reverse" title="+6 uur">
+      <button name="action" class="btn btn_mid" value="fast_reverse" title="+6 uur">
         <img src="static/ffwd.png" alt="prev" border="0" style="display:inline-block; height:1.5em; width:auto;" />
       </button>
       <button name="action" class="btn btn_mid" value="first">


### PR DESCRIPTION
**Datetime picker**
To be able to navigate easier through the graphs or logs in this branch a datetime picker is added.

<img width="720" height="552" alt="image" src="https://github.com/user-attachments/assets/480bb8eb-f71f-46d5-82df-4d7110559191" />

---
**Added session variables**
The application used global variables to track `active_view `and `active_time`. This caused race conditions and inconsistent behavior because Flask is multithreaded. One user's actions (or a second tab) could overwrite the state and could cause unpredictable behavior.

This branch replaced global variables with Flask Session variables (flask.session). This ensures the user state is stored per-client in a secure cookie, making the application thread-safe.
This gives a more stable switching back and forward between graph or log while also switching back and forward through time or using the datetime picker.

Kind regards,

Dogooder from Tweakers