### PR TITLE
Feature: Add fallback option for source of day ahead prices

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -1294,7 +1294,8 @@ System uses tariff active on optimization date.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `source day ahead` | string | No | `"nordpool"` | Source for day-ahead prices. Options: `nordpool`, `entsoe`, `tibber` |
+| `source day ahead` | string | No | `"nordpool"` | Source for day-ahead prices. Options: `nordpool`, `entsoe`, `tibber`, `easyenergy` |
+| `source day ahead fallback` | list[string] | No | `[]` | Fallback sources for day-ahead prices (used when primary source fails) |
 | `entsoe-api-key` | [SecretStr](#secretstr) (optional) | No | `null` | ENTSO-E API key (can use !secret) _Required for entsoe source, use !secret_ |
 | `energy taxes consumption` | object | Yes | — | Energy taxes for consumption by date (YYYY-MM-DD -> euro/kWh ex VAT) (Unit: `€/kWh`) _Dict with YYYY-MM-DD keys, float values (ex VAT)_ |
 | `energy taxes production` | object | Yes | — | Energy taxes for production by date (YYYY-MM-DD -> euro/kWh ex VAT) (Unit: `€/kWh`) _Dict with YYYY-MM-DD keys, float values (ex VAT)_ |
@@ -1311,6 +1312,10 @@ System uses tariff active on optimization date.
 **`source day ahead`**
 
 Data source for day-ahead electricity market prices. 'nordpool' for Nordic/Baltic, 'entsoe' for European markets, 'tibber' if using Tibber integration.
+
+**`source day ahead fallback`**
+
+Optional fallback sources to try when the primary 'source day ahead' is unavailable or returns no data. Example: ['entsoe', 'tibber'].
 
 **`entsoe-api-key`**
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -1299,7 +1299,8 @@ System uses tariff active on optimization date.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `source day ahead` | string | No | `"nordpool"` | Source for day-ahead prices. Options: `nordpool`, `entsoe`, `tibber` |
+| `source day ahead` | string | No | `"nordpool"` | Source for day-ahead prices. Options: `nordpool`, `entsoe`, `tibber`, `easyenergy` |
+| `source day ahead fallback` | list[string] | No | `[]` | Fallback sources for day-ahead prices (used when primary source fails) |
 | `entsoe-api-key` | [SecretStr](#secretstr) (optional) | No | `null` | ENTSO-E API key (can use !secret) _Required for entsoe source, use !secret_ |
 | `energy taxes consumption` | object | Yes | — | Energy taxes for consumption by date (YYYY-MM-DD -> euro/kWh ex VAT) (Unit: `€/kWh`) _Dict with YYYY-MM-DD keys, float values (ex VAT)_ |
 | `energy taxes production` | object | Yes | — | Energy taxes for production by date (YYYY-MM-DD -> euro/kWh ex VAT) (Unit: `€/kWh`) _Dict with YYYY-MM-DD keys, float values (ex VAT)_ |
@@ -1316,6 +1317,10 @@ System uses tariff active on optimization date.
 **`source day ahead`**
 
 Data source for day-ahead electricity market prices. 'nordpool' for Nordic/Baltic, 'entsoe' for European markets, 'tibber' if using Tibber integration.
+
+**`source day ahead fallback`**
+
+Optional fallback sources to try when the primary 'source day ahead' is unavailable or returns no data. Example: ['entsoe', 'tibber'].
 
 **`entsoe-api-key`**
 

--- a/config_schema.json
+++ b/config_schema.json
@@ -2059,11 +2059,29 @@
           "enum": [
             "nordpool",
             "entsoe",
-            "tibber"
+            "tibber",
+            "easyenergy"
           ],
           "title": "Source Day Ahead",
           "type": "string",
           "x-help": "Data source for day-ahead electricity market prices. 'nordpool' for Nordic/Baltic, 'entsoe' for European markets, 'tibber' if using Tibber integration.",
+          "x-ui-section": "Prices"
+        },
+        "source day ahead fallback": {
+          "default": [],
+          "description": "Fallback sources for day-ahead prices (used when primary source fails)",
+          "items": {
+            "enum": [
+              "nordpool",
+              "entsoe",
+              "tibber",
+              "easyenergy"
+            ],
+            "type": "string"
+          },
+          "title": "Source Day Ahead Fallback",
+          "type": "array",
+          "x-help": "Optional fallback sources to try when the primary 'source day ahead' is unavailable or returns no data. Example: ['entsoe', 'tibber'].",
           "x-ui-section": "Prices"
         },
         "entsoe-api-key": {

--- a/config_schema.json
+++ b/config_schema.json
@@ -2073,11 +2073,29 @@
           "enum": [
             "nordpool",
             "entsoe",
-            "tibber"
+            "tibber",
+            "easyenergy"
           ],
           "title": "Source Day Ahead",
           "type": "string",
           "x-help": "Data source for day-ahead electricity market prices. 'nordpool' for Nordic/Baltic, 'entsoe' for European markets, 'tibber' if using Tibber integration.",
+          "x-ui-section": "Prices"
+        },
+        "source day ahead fallback": {
+          "default": [],
+          "description": "Fallback sources for day-ahead prices (used when primary source fails)",
+          "items": {
+            "enum": [
+              "nordpool",
+              "entsoe",
+              "tibber",
+              "easyenergy"
+            ],
+            "type": "string"
+          },
+          "title": "Source Day Ahead Fallback",
+          "type": "array",
+          "x-help": "Optional fallback sources to try when the primary 'source day ahead' is unavailable or returns no data. Example: ['entsoe', 'tibber'].",
           "x-ui-section": "Prices"
         },
         "entsoe-api-key": {

--- a/dao/DOCS.md
+++ b/dao/DOCS.md
@@ -657,6 +657,7 @@ Het is allemaal optioneel.
 | **meteoserver-model**     |                               | string           | harmonie                           | keuze uit harmonie of gfs                          |
 | **meteoserver-attempts**  |                               | getal            | 2                                  | aantal ophaal pogingen                             |
 | **prices**                | source day ahead              | string           | nordpool                           | keuze uit: nordpool / entsoe / easyenergy / tibber |
+|                           | source day ahead fallback     | list             | []                                 | fallback bronnen (op volgorde) als de eerste bron geen data geeft |
 |                           | entsoe-api-key                | string           |                                    | alleen bij entsoe als source                       |
 |                           | regular high                  | getal            |                                    |                                                    |
 |                           | regular low                   | getal            |                                    |                                                    |
@@ -932,6 +933,11 @@ De meteodata worden opgehaald bij meteoserver. Ook hiervoor heb je een key nodig
    * entsoe
    * easyenergy
    * tibber<br>
+
+ * source day ahead fallback, default []
+     Optioneel: lijst van fallback bronnen (op volgorde) die geprobeerd worden als de primaire bron geen data geeft.
+     Voorbeeld (1 fallback): `["nordpool"]`  
+     Voorbeeld (meerdere fallbacks): `["entsoe", "tibber"]`
 
     Als je kiest voor **entsoe** dan moet je hieronder een api key invullen.
  * entsoe-api-key:  

--- a/dao/DOCS.md
+++ b/dao/DOCS.md
@@ -653,6 +653,7 @@ Het is allemaal optioneel.
 | **meteoserver-model**     |                               | string           | harmonie                           | keuze uit harmonie of gfs                          |
 | **meteoserver-attempts**  |                               | getal            | 2                                  | aantal ophaal pogingen                             |
 | **prices**                | source day ahead              | string           | nordpool                           | keuze uit: nordpool / entsoe / easyenergy / tibber |
+|                           | source day ahead fallback     | list             | []                                 | fallback bronnen (op volgorde) als de eerste bron geen data geeft |
 |                           | entsoe-api-key                | string           |                                    | alleen bij entsoe als source                       |
 |                           | regular high                  | getal            |                                    |                                                    |
 |                           | regular low                   | getal            |                                    |                                                    |
@@ -928,6 +929,11 @@ De meteodata worden opgehaald bij meteoserver. Ook hiervoor heb je een key nodig
    * entsoe
    * easyenergy
    * tibber<br>
+
+ * source day ahead fallback, default []
+     Optioneel: lijst van fallback bronnen (op volgorde) die geprobeerd worden als de primaire bron geen data geeft.
+     Voorbeeld (1 fallback): `["nordpool"]`  
+     Voorbeeld (meerdere fallbacks): `["entsoe", "tibber"]`
 
     Als je kiest voor **entsoe** dan moet je hieronder een api key invullen.
  * entsoe-api-key:  

--- a/dao/lib/da_prices.py
+++ b/dao/lib/da_prices.py
@@ -22,7 +22,18 @@ class DaPrices:
 
     def get_prices(
         self, source, _start: datetime.datetime = None, _end: datetime.datetime = None
-    ):
+    ) -> tuple[bool, bool]:
+        """
+        Fetch and store day-ahead prices.
+
+        Returns:
+            A tuple of two booleans: (available, fetched_now).
+
+            - available: True if day-ahead prices are available after this call (either they were
+              already present in the database, or they were fetched and saved now).
+            - fetched_now: True only when this call performed a fetch and saved data. This is used
+              by `DaBase.get_day_ahead_prices()` to log "fetched now" vs "already present".
+        """
         if self.interval == "1hour":
             resolution = 60
         else:
@@ -61,7 +72,7 @@ class DaPrices:
                     end = tz.normalize(tz.localize(end))
                 if present >= (end - datetime.timedelta(hours=1)):
                     logging.info(f"Day ahead data already present")
-                    return
+                    return True, False
 
         # day-ahead market prices (€/MWh)
         if source.lower() == "entsoe":
@@ -80,6 +91,10 @@ class DaPrices:
             except Exception as ex:
                 logging.error(ex)
                 logging.error(f"Geen data van Entsoe: tussen {start} en {end}")
+                return False, False
+            if len(da_prices.index) == 0:
+                logging.error(f"Geen data van Entsoe: tussen {start} en {end}")
+                return False, False
             if len(da_prices.index) > 0:
                 df_db = pd.DataFrame(columns=["time", "code", "value"])
                 da_prices = (
@@ -106,6 +121,7 @@ class DaPrices:
                         logging.warning(
                             f"Geen data van Entsoe tussen {last_time_dt} en {end_dt}"
                         )
+                return True, True
 
         if source.lower() == "nordpool":
             # ophalen bij Nordpool
@@ -114,25 +130,27 @@ class DaPrices:
                 end_date = None
             else:
                 end_date = start
+            expected_count = 24 if self.interval == "1hour" else 96
             try:
                 act_spot_prices = prices_spot.fetch(
                     areas=[self.country], end_date=end_date, resolution=resolution
                 )
             except ConnectionError:
                 logging.error(f"Geen data van Nordpool: tussen {start} en {end}")
-                return
+                return False, False
             except Exception as ex:
                 logging.exception(ex)
                 logging.error(f"Geen data van Nordpool: tussen {start} en {end}")
-                return
+                return False, False
             if act_spot_prices is None:
                 logging.error(f"Geen data van Nordpool: tussen {start} en {end}")
-                return
+                return False, False
 
             act_values = act_spot_prices["areas"][self.country]["values"]
             s = pp.pformat(act_values, indent=2)
             logging.info(f"Day ahead prijzen van Nordpool:\n {s}")
             df_db = pd.DataFrame(columns=["time", "code", "value"])
+            time_ts = None
             for act_value in act_values:
                 time_dt = act_value["start"]
                 time_ts = int(time_dt.timestamp())
@@ -147,10 +165,15 @@ class DaPrices:
                 f"{end_date.strftime('%Y-%m-%d') if end_date else 'tomorrow'}"
                 f" (source: nordpool, db-records): \n {df_db.to_string(index=False)}"
             )
-            if len(df_db) < 24 and datetime.datetime.fromtimestamp(
-                time_ts
-            ) < datetime.datetime(
-                end_date.year, end_date.month, end_date.day, end_date.hour
+            if len(df_db) == 0:
+                logging.error(f"Geen bruikbare Nordpool data: tussen {start} en {end}")
+                return False, False
+            if (
+                end_date is not None
+                and time_ts is not None
+                and len(df_db) < expected_count
+                and datetime.datetime.fromtimestamp(time_ts)
+                < datetime.datetime(end_date.year, end_date.month, end_date.day, end_date.hour)
             ):
                 logging.warning(
                     f"Retrieve of day ahead prices for "
@@ -158,6 +181,7 @@ class DaPrices:
                     f"failed"
                 )
             self.db_da.savedata(df_db)
+            return True, True
 
         if source.lower() == "easyenergy":
             # ophalen bij EasyEnergy
@@ -170,10 +194,18 @@ class DaPrices:
                 + "&endTimestamp="
                 + endstr
             )
-            resp = get(url)
-            logging.debug(resp.text)
-            json_object = json.loads(resp.text)
-            df = pd.DataFrame.from_records(json_object)
+            try:
+                resp = get(url)
+                logging.debug(resp.text)
+                json_object = json.loads(resp.text)
+                df = pd.DataFrame.from_records(json_object)
+            except Exception as ex:
+                logging.error(ex)
+                logging.error(f"Geen data van EasyEnergy: tussen {start} en {end}")
+                return False, False
+            if len(df.index) == 0:
+                logging.error(f"Geen data van EasyEnergy: tussen {start} en {end}")
+                return False, False
             logging.info(
                 f"Day ahead prijzen van Easyenergy:\n {df.to_string(index=False)}"
             )
@@ -191,6 +223,7 @@ class DaPrices:
                 f"{df_db.to_string(index=False)}"
             )
             self.db_da.savedata(df_db)
+            return True, True
 
         if source.lower() == "tibber":
             now_ts = datetime.datetime.now().timestamp()
@@ -250,17 +283,22 @@ class DaPrices:
                 "Authorization": "Bearer " + api_token,
                 "content-type": "application/json",
             }
-            resp = post(url, headers=headers, data=query)
-            tibber_dict = json.loads(resp.text)
-            today_nodes = tibber_dict["data"]["viewer"]["homes"][0][
-                "currentSubscription"
-            ]["priceInfo"]["today"]
-            tomorrow_nodes = tibber_dict["data"]["viewer"]["homes"][0][
-                "currentSubscription"
-            ]["priceInfo"]["tomorrow"]
-            range_nodes = tibber_dict["data"]["viewer"]["homes"][0][
-                "currentSubscription"
-            ]["priceInfoRange"]["nodes"]
+            try:
+                resp = post(url, headers=headers, data=query)
+                tibber_dict = json.loads(resp.text)
+                today_nodes = tibber_dict["data"]["viewer"]["homes"][0]["currentSubscription"][
+                    "priceInfo"
+                ]["today"]
+                tomorrow_nodes = tibber_dict["data"]["viewer"]["homes"][0]["currentSubscription"][
+                    "priceInfo"
+                ]["tomorrow"]
+                range_nodes = tibber_dict["data"]["viewer"]["homes"][0]["currentSubscription"][
+                    "priceInfoRange"
+                ]["nodes"]
+            except Exception as ex:
+                logging.error(ex)
+                logging.error(f"Geen data van Tibber: tussen {start} en {end}")
+                return False, False
             df_db = pd.DataFrame(columns=["time", "code", "value"])
             for lst in [today_nodes, tomorrow_nodes, range_nodes]:
                 for node in lst:
@@ -275,4 +313,11 @@ class DaPrices:
                 f"Day ahead prijzen (source: tibber, db-records): \n "
                 f"{df_db.to_string(index=False)}"
             )
+            if len(df_db) == 0:
+                logging.error(f"Geen bruikbare Tibber data: tussen {start} en {end}")
+                return False, False
             self.db_da.savedata(df_db)
+            return True, True
+
+        logging.error(f"Onbekende day-ahead source: {source}")
+        return False, False

--- a/dao/prog/config/models/pricing.py
+++ b/dao/prog/config/models/pricing.py
@@ -11,7 +11,7 @@ from datetime import date
 class PricingConfig(BaseModel):
     """Day-ahead pricing and tariff configuration."""
     
-    source_day_ahead: Literal['nordpool', 'entsoe', 'tibber'] = Field(
+    source_day_ahead: Literal["nordpool", "entsoe", "tibber", "easyenergy"] = Field(
         default='nordpool',
         alias="source day ahead",
         description="Source for day-ahead prices",
@@ -19,6 +19,19 @@ class PricingConfig(BaseModel):
             "x-help": "Data source for day-ahead electricity market prices. 'nordpool' for Nordic/Baltic, 'entsoe' for European markets, 'tibber' if using Tibber integration.",
             "x-ui-section": "Prices"
         }
+    )
+    source_day_ahead_fallback: list[Literal["nordpool", "entsoe", "tibber", "easyenergy"]] = Field(
+        default_factory=list,
+        alias="source day ahead fallback",
+        description="Fallback sources for day-ahead prices (used when primary source fails)",
+        json_schema_extra={
+            "default": [],
+            "x-help": (
+                "Optional fallback sources to try when the primary 'source day ahead' is unavailable "
+                "or returns no data. Example: ['entsoe', 'tibber']."
+            ),
+            "x-ui-section": "Prices",
+        },
     )
     entsoe_api_key: Optional[SecretStr] = Field(
         default=None,

--- a/dao/prog/da_base.py
+++ b/dao/prog/da_base.py
@@ -328,8 +328,34 @@ class DaBase(hass.Hass):
         report.consolidate_data(start_dt)
 
     def get_day_ahead_prices(self):
-        source = self.prices_options.source_day_ahead if self.prices_options else "nordpool"
-        self.prices.get_prices(source)
+        primary_source = (
+            self.prices_options.source_day_ahead if self.prices_options else "nordpool"
+        )
+        fallback_sources = []
+        if self.prices_options is not None:
+            fallback_sources = getattr(self.prices_options, "source_day_ahead_fallback", []) or []
+
+        sources = []
+        for source in [primary_source, *fallback_sources]:
+            if not source:
+                continue
+            source_norm = str(source).strip().lower()
+            if source_norm not in sources:
+                sources.append(source_norm)
+
+        for source in sources:
+            ok, fetched = self.prices.get_prices(source)
+            if ok:
+                if fetched:
+                    logging.info(f"Day-ahead prijzen opgehaald via bron: {source}")
+                else:
+                    logging.info("Day-ahead prijzen waren al aanwezig; ophalen is overgeslagen.")
+                return
+            logging.warning(f"Day-ahead bron '{source}' leverde geen data; trying fallback.")
+
+        logging.error(
+            "Geen day-ahead prijzen opgehaald: alle geconfigureerde bronnen faalden of leverden geen data."
+        )
 
     def save_df(self, tablename: str, tijd: list, df: pd.DataFrame):
         """


### PR DESCRIPTION
Deze PR voegt de optie toe om een fallback source in te stellen voor day ahead prices. De optie wordt aangeroepen als de primaire bron faalt. Geen idee of deze extra functionaliteit past in de filosofie van de applicatie. Het is een extra optie die ook leeg mag zijn en is backwards compatible. Reden is dat entsoe niet altijd even betrouwbaar is in het leveren van data.