### PR TITLE
Fix for preventing immediate turn on of the PV switch after it has been turned off (when PV is defined at battery). Closes #654

### DIFF
--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -3900,7 +3900,6 @@ class DaCalc(DaBase):
                                 else:
                                     self.turn_off(entity_pv_switch)
                                     logging.info(f"PV {pv_name} uitgezet")
-                            self.turn_on(entity_pv_switch)
 
             ##################################################
             # heatpump


### PR DESCRIPTION
removed self.turn_on(entity_pv_switch) to prevent immediate turn on of the PV switch after it has been turned off (battery)