### PR TITLE
Meer robuuste scheduler?

### DIFF
--- a/dao/prog/da_scheduler.py
+++ b/dao/prog/da_scheduler.py
@@ -1,6 +1,13 @@
 import datetime
+import fcntl
+import logging
+import os
+import signal
+import subprocess
 import sys
 import time
+from pathlib import Path
+
 from da_base import DaBase
 
 
@@ -9,6 +16,145 @@ class DaScheduler(DaBase):
         super().__init__(file_name)
         self.active = self.config.scheduler.active
         self.scheduler_tasks = {entry.time: entry.action for entry in self.config.scheduler.schedule}
+
+        # Heartbeat monitored by watchdog.sh.
+        self._heartbeat_path = Path("/tmp/dao_scheduler_heartbeat")
+
+        # Poll interval while waiting for subprocess completion.
+        self._poll_s = 5
+
+        # Generic timeout for all tasks, with a single override for ML training.
+        self._default_timeout_s = 10 * 60
+        self._train_timeout_s = 30 * 60
+
+        # Only lock ML training: on watchdog restarts (config change / heartbeat) it's the only task where a
+        # concurrent second run is both plausible and costly; other tasks are short and safe to re-run.
+        self._no_overlap_actions = {"train_ml_predictions"}
+        self._lock_dir = Path("/tmp/dao_scheduler_locks")
+        self._lock_dir.mkdir(parents=True, exist_ok=True)
+
+        # Inherit run.sh environment and current workdir.
+        self._env = os.environ.copy()
+        self._workdir = os.getcwd()
+
+    def _touch_heartbeat(self):
+        # Best effort: watchdog signal only; must not break scheduling.
+        try:
+            self._heartbeat_path.write_text(str(time.time()))
+        except Exception:
+            # Don't let heartbeat failures break scheduling.
+            pass
+
+    def _timeout_for_action(self, action: str) -> int:
+        if action == "train_ml_predictions":
+            return self._train_timeout_s
+        return self._default_timeout_s
+
+    def _task_key_for_action(self, action: str) -> str | None:
+        for task_key, task in self.tasks.items():
+            if task.get("function") == action:
+                return task_key
+        return None
+
+    def _acquire_action_lock(self, action: str):
+        lock_path = self._lock_dir / f"{action}.lock"
+        f = open(lock_path, "w")
+        try:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            f.close()
+            return None
+
+        f.seek(0)
+        f.truncate()
+        f.write(f"pid={os.getpid()}\n")
+        f.write(f"action={action}\n")
+        f.write(f"ts={time.time()}\n")
+        f.flush()
+        return f
+
+    @staticmethod
+    def _release_action_lock(f):
+        try:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        finally:
+            f.close()
+
+    def _run_action_subprocess(self, action: str):
+        task_key = self._task_key_for_action(action)
+        if task_key is None:
+            logging.error(f"scheduler: no task found for action={action}")
+            return
+
+        task = self.tasks.get(task_key) or {}
+        cmd = task.get("cmd")
+        if not cmd:
+            logging.error(f"scheduler: task_key={task_key} has no cmd for action={action}")
+            return
+
+        timeout_s = int(self._timeout_for_action(action))
+        start_ts = time.time()
+
+        logging.info(
+            f"scheduler: start action={action} task_key={task_key} timeout_s={timeout_s} cmd={cmd}"
+        )
+
+        # New process group so we can kill the full tree (joblib/loky).
+        proc = subprocess.Popen(
+            cmd,
+            cwd=self._workdir,
+            env=self._env,
+            preexec_fn=os.setsid,
+        )
+
+        # Poll-loop keeps heartbeat alive during long tasks and enables soft timeout handling (try SIGTERM before SIGKILL).
+        while True:
+            self._touch_heartbeat()
+
+            exit_code = proc.poll()
+            if exit_code is not None:
+                dur = int(time.time() - start_ts)
+                logging.info(
+                    f"scheduler: done action={action} exit_code={exit_code} duration_s={dur}"
+                )
+                return
+
+            runtime_s = time.time() - start_ts
+            if runtime_s > timeout_s:
+                dur = int(runtime_s)
+                logging.error(
+                    f"scheduler: timeout action={action} pid={proc.pid} duration_s={dur} -> SIGTERM"
+                )
+                try:
+                    os.killpg(proc.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    return
+
+                grace_start = time.time()
+                while True:
+                    self._touch_heartbeat()
+                    exit_code = proc.poll()
+                    if exit_code is not None:
+                        logging.error(
+                            f"scheduler: terminated action={action} exit_code={exit_code}"
+                        )
+                        return
+                    if time.time() - grace_start > 15:
+                        break
+                    time.sleep(1)
+
+                logging.error(
+                    f"scheduler: still running action={action} pid={proc.pid} -> SIGKILL"
+                )
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    return
+                exit_code = proc.wait()
+                logging.error(f"scheduler: killed action={action} exit_code={exit_code}")
+                return
+
+            time.sleep(self._poll_s)
 
     def scheduler(self):
         # if not (self.notification_entity is None) and self.notification_opstarten:
@@ -22,6 +168,9 @@ class DaScheduler(DaBase):
             )
             # wacht tot hele minuut 0% cpu
             time.sleep((next_min - t).total_seconds())
+
+            # heartbeat at least once per minute (even when inactive)
+            self._touch_heartbeat()
             if not self.active:
                 continue
             hour = next_min.hour
@@ -31,26 +180,32 @@ class DaScheduler(DaBase):
             key1 = "xx" + str(minute).zfill(2)
             # iedere minuut in een uur voorbeeld 02xx
             key2 = str(hour).zfill(2) + "xx"
-            tasks = []
+            actions = []
             for key in self.scheduler_tasks:
                 if key == key0:
-                    tasks.append(self.scheduler_tasks[key])
+                    actions.append(self.scheduler_tasks[key])
                 elif key == key1:
-                    tasks.append(self.scheduler_tasks[key])
+                    actions.append(self.scheduler_tasks[key])
                 elif key == key2:
-                    tasks.append(self.scheduler_tasks[key])
-            for task in tasks:
-                for key_task in self.tasks:
-                    if self.tasks[key_task]["function"] == task:
-                        try:
-                            self.run_task_function(key_task, True)
-                        except KeyboardInterrupt:
-                            sys.exit()
-                            pass
-                        except Exception as e:
-                            print(e)
-                            continue
-                        break
+                    actions.append(self.scheduler_tasks[key])
+
+            for action in actions:
+                lock_f = None
+                if action in self._no_overlap_actions:
+                    lock_f = self._acquire_action_lock(action)
+                    if lock_f is None:
+                        logging.warning(f"scheduler: skip action={action} (already running)")
+                        continue
+
+                try:
+                    self._run_action_subprocess(action)
+                except KeyboardInterrupt:
+                    sys.exit()
+                except Exception:
+                    logging.exception(f"scheduler: exception action={action}")
+                finally:
+                    if lock_f is not None:
+                        self._release_action_lock(lock_f)
 
 
 def main():

--- a/dao/prog/da_scheduler.py
+++ b/dao/prog/da_scheduler.py
@@ -12,24 +12,46 @@ from da_base import DaBase
 
 
 class DaScheduler(DaBase):
+    """Scheduler with selective subprocess execution and watchdog heartbeat.
+
+    ``watchdog.sh`` restarts the scheduler child on crash (process gone) or on a stale
+    heartbeat file (process still alive but hangs).
+    
+    Actions listed in ``_SUBPROCESS_ACTIONS`` run in a child process; all other
+    scheduled actions run inline in this process (``run_task_function``).
+
+    We use a subprocess when a task can be long-running: the parent stays in a poll
+    loop, refreshes the heartbeat about every ``_poll_s`` seconds, and can stop the child
+    on timeout (SIGTERM/SIGKILL on the process group) without killing the scheduler.
+    
+    We use inline for short or frequent tasks (e.g. quarterly ``calc``): each
+    start of a subprocess forks a new Python interpreter and adds some overhead,
+    which might add up when the same action runs frequently.
+
+    Trade-off for inline tasks: no heartbeat updates while the task runs, so a
+    task longer than the watchdog ``MAX_HEARTBEAT_AGE_S`` can look like a hang and cause
+    a watchdog restart.
+    """
+
+    # Subprocess actions; flock per action so we never start a duplicate long job (e.g. after watchdog
+    # restart).
+    _SUBPROCESS_ACTIONS = ("train_ml_predictions", "calc_baseloads")
+
     def __init__(self, file_name: str = None):
         super().__init__(file_name)
         self.active = self.config.scheduler.active
         self.scheduler_tasks = {entry.time: entry.action for entry in self.config.scheduler.schedule}
-
+        
         # Heartbeat monitored by watchdog.sh.
         self._heartbeat_path = Path("/tmp/dao_scheduler_heartbeat")
-
+        
         # Poll interval while waiting for subprocess completion.
         self._poll_s = 5
 
-        # Generic timeout for all tasks, with a single override for ML training.
-        self._default_timeout_s = 10 * 60
-        self._train_timeout_s = 30 * 60
+        # Generic timeout for all tasks in subprocesses.
+        self._subprocess_timeout_s = 30 * 60
 
-        # Only lock ML training: on watchdog restarts (config change / heartbeat) it's the only task where a
-        # concurrent second run is both plausible and costly; other tasks are short and safe to re-run.
-        self._no_overlap_actions = {"train_ml_predictions"}
+        # Lock directory for per-action locks.
         self._lock_dir = Path("/tmp/dao_scheduler_locks")
         self._lock_dir.mkdir(parents=True, exist_ok=True)
 
@@ -38,17 +60,11 @@ class DaScheduler(DaBase):
         self._workdir = os.getcwd()
 
     def _touch_heartbeat(self):
-        # Best effort: watchdog signal only; must not break scheduling.
         try:
             self._heartbeat_path.write_text(str(time.time()))
         except Exception:
             # Don't let heartbeat failures break scheduling.
             pass
-
-    def _timeout_for_action(self, action: str) -> int:
-        if action == "train_ml_predictions":
-            return self._train_timeout_s
-        return self._default_timeout_s
 
     def _task_key_for_action(self, action: str) -> str | None:
         for task_key, task in self.tasks.items():
@@ -92,11 +108,12 @@ class DaScheduler(DaBase):
             logging.error(f"scheduler: task_key={task_key} has no cmd for action={action}")
             return
 
-        timeout_s = int(self._timeout_for_action(action))
+        timeout_s = int(self._subprocess_timeout_s)
         start_ts = time.time()
 
         logging.info(
-            f"scheduler: start action={action} task_key={task_key} timeout_s={timeout_s} cmd={cmd}"
+            f"scheduler: start subprocess action={action} task_key={task_key} "
+            f"timeout_s={timeout_s} cmd={cmd}"
         )
 
         # New process group so we can kill the full tree (joblib/loky).
@@ -107,16 +124,21 @@ class DaScheduler(DaBase):
             preexec_fn=os.setsid,
         )
 
-        # Poll-loop keeps heartbeat alive during long tasks and enables soft timeout handling (try SIGTERM before SIGKILL).
+        # Poll-loop keeps heartbeat alive during long tasks and enables timeout handling (try SIGTERM before SIGKILL).
         while True:
             self._touch_heartbeat()
 
             exit_code = proc.poll()
             if exit_code is not None:
                 dur = int(time.time() - start_ts)
-                logging.info(
-                    f"scheduler: done action={action} exit_code={exit_code} duration_s={dur}"
-                )
+                if exit_code == 0:
+                    logging.info(
+                        f"scheduler: done action={action} exit_code={exit_code} duration_s={dur}"
+                    )
+                else:
+                    logging.error(
+                        f"scheduler: failed action={action} exit_code={exit_code} duration_s={dur}"
+                    )
                 return
 
             runtime_s = time.time() - start_ts
@@ -156,6 +178,22 @@ class DaScheduler(DaBase):
 
             time.sleep(self._poll_s)
 
+    def _run_action_inline(self, action: str):
+        task_key = self._task_key_for_action(action)
+        if task_key is None:
+            logging.error(f"scheduler: no task found for action={action}")
+            return
+
+        logging.info(f"scheduler: start inline action={action} task_key={task_key}")
+        self.run_task_function(task_key)
+        logging.info(f"scheduler: done inline action={action} task_key={task_key}")
+
+    def _run_action(self, action: str):
+        if action in self._SUBPROCESS_ACTIONS:
+            self._run_action_subprocess(action)
+        else:
+            self._run_action_inline(action)
+
     def scheduler(self):
         # if not (self.notification_entity is None) and self.notification_opstarten:
         #     self.set_value(self.notification_entity, "DAO scheduler gestart " +
@@ -169,10 +207,11 @@ class DaScheduler(DaBase):
             # wacht tot hele minuut 0% cpu
             time.sleep((next_min - t).total_seconds())
 
-            # heartbeat at least once per minute (even when inactive)
+            # heartbeat once per minute
             self._touch_heartbeat()
             if not self.active:
                 continue
+
             hour = next_min.hour
             minute = next_min.minute
             key0 = str(hour).zfill(2) + str(minute).zfill(2)
@@ -191,14 +230,14 @@ class DaScheduler(DaBase):
 
             for action in actions:
                 lock_f = None
-                if action in self._no_overlap_actions:
+                if action in self._SUBPROCESS_ACTIONS:
                     lock_f = self._acquire_action_lock(action)
                     if lock_f is None:
                         logging.warning(f"scheduler: skip action={action} (already running)")
                         continue
 
                 try:
-                    self._run_action_subprocess(action)
+                    self._run_action(action)
                 except KeyboardInterrupt:
                     sys.exit()
                 except Exception:
@@ -210,6 +249,8 @@ class DaScheduler(DaBase):
 
 def main():
     da_sched = DaScheduler("../data/options.json")
+    # Touch heartbeat as soon as init finishes; doing it later can trigger watchdog restart on stale file.
+    da_sched._touch_heartbeat()
     da_sched.scheduler()
 
 

--- a/dao/run/watchdog.sh
+++ b/dao/run/watchdog.sh
@@ -1,8 +1,70 @@
 #!/bin/sh
+
+HEARTBEAT="/tmp/dao_scheduler_heartbeat"
+# Scheduler updates heartbeat every ~5s while tasks run; 120s leaves enough slack.
+MAX_HEARTBEAT_AGE_S=120
+# Users expect config changes to apply immediately; polling every 1s keeps reload latency low
+CHECK_INTERVAL_S=1
+
+start_child() {
+  "$@" &
+  CHILD_PID=$!
+  echo "watchdog: started da_scheduler pid=$CHILD_PID cmd=$*"
+}
+
+stop_child() {
+  if [ -n "$CHILD_PID" ] && kill -0 "$CHILD_PID" 2>/dev/null; then
+    echo "watchdog: stopping da_scheduler pid=$CHILD_PID"
+    kill "$CHILD_PID" || true
+    sleep 2
+    if kill -0 "$CHILD_PID" 2>/dev/null; then
+      echo "watchdog: da_scheduler still alive -> SIGKILL pid=$CHILD_PID"
+      kill -9 "$CHILD_PID" || true
+    fi
+  fi
+}
+
+start_inotify() {
+  inotifywait "../data/options.json" "../data/secrets.json" -e modify &
+  INOTIFY_PID=$!
+}
+
+start_child "$@"
+start_inotify
+
 while true; do
-  $@ &
-  PID=$!
-  inotifywait "../data/options.json" "../data/secrets.json" -e modify
-  kill $PID
+  # 1) Child exited/crashed -> restart
+  if ! kill -0 "$CHILD_PID" 2>/dev/null; then
+    echo "watchdog: da_scheduler exited -> restart"
+    start_child "$@"
+  fi
+
+  # 2) Config modified -> restart child (inotify exits after first modify event)
+  if ! kill -0 "$INOTIFY_PID" 2>/dev/null; then
+    echo "watchdog: config modified -> restart da_scheduler"
+    stop_child
+    start_child "$@"
+    start_inotify
+  fi
+
+  # 3) Heartbeat stale -> restart child
+  if [ -f "$HEARTBEAT" ]; then
+    now=$(date +%s)
+    hb=$(cat "$HEARTBEAT" 2>/dev/null || echo 0)
+    hb_int=$(echo "$hb" | cut -d. -f1)
+    age=$((now - hb_int))
+    if [ "$age" -gt "$MAX_HEARTBEAT_AGE_S" ]; then
+      echo "watchdog: heartbeat stale age=${age}s -> restart da_scheduler"
+      stop_child
+      start_child "$@"
+    fi
+  fi
+
+  # Ensure an inotify watcher is running
+  if [ -z "$INOTIFY_PID" ] || ! kill -0 "$INOTIFY_PID" 2>/dev/null; then
+    start_inotify
+  fi
+
+  sleep "$CHECK_INTERVAL_S"
 done
 

--- a/dao/run/watchdog.sh
+++ b/dao/run/watchdog.sh
@@ -1,12 +1,21 @@
 #!/bin/sh
 
+# Heartbeat file
 HEARTBEAT="/tmp/dao_scheduler_heartbeat"
-# Scheduler updates heartbeat every ~5s while tasks run; 120s leaves enough slack.
-MAX_HEARTBEAT_AGE_S=120
-# Users expect config changes to apply immediately; polling every 1s keeps reload latency low
-CHECK_INTERVAL_S=1
+
+# Stale-heartbeat threshold: watchdog restarts the scheduler when the heartbeat file is
+# older than MAX_HEARTBEAT_AGE_S seconds (checked every CHECK_INTERVAL_S). Must be >= longest inline
+# scheduler task; inline runs do not refresh the heartbeat until they finish. Subprocess
+# actions refresh it in a poll loop. Higher heartbeat_age = more tolerance for long inline work but slower hang recovery.
+MAX_HEARTBEAT_AGE_S=450
+
+# How often the loop checks child, inotify, and heartbeat age.
+# Users expect config changes to apply immediately; polling every 2s keeps reload latency low
+CHECK_INTERVAL_S=2
 
 start_child() {
+  # Drop stale heartbeat from a previous run so we don't restart-loop before the child writes.
+  rm -f "$HEARTBEAT"
   "$@" &
   CHILD_PID=$!
   echo "watchdog: started da_scheduler pid=$CHILD_PID cmd=$*"
@@ -67,4 +76,3 @@ while true; do
 
   sleep "$CHECK_INTERVAL_S"
 done
-


### PR DESCRIPTION
Hi,
De watchdog en scheduler knalden er bij mij geregeld uit, mn na ML training en DAO staat dan stil. Dat kwam door te weinig memory op mijn HA VM en de kernel grijpt dan hard in (Out of memory: Killed process ...). Op zich snel gefixt door wat extra memory toe te wijzen maar het bracht mij wel op het idee om de taken van de scheduler in subprocessen onder te brengen (en dat te bewaken met timeouts en een heartbeat) zodat een taak niet de hele scheduler-loop mee neemt als het mis gaat.

Dat werkt op zich prima maar de drawback is wel dat het geheel iets meer resources vreet. Of het middel erger is dan de kwaal weet ik eigenlijk ook niet, dat laat ik aan jou :-) Maar ik dacht, laat ik het iig even tegen je aan houden voordat ik het weer weggooi.