### PR TITLE
Update da_report.py to correct baseload for machine usage

### DIFF
--- a/dao/prog/da_report.py
+++ b/dao/prog/da_report.py
@@ -1497,6 +1497,7 @@ class Report(DaBase):
                 - row.ev
                 - row.wp
                 - row.boil
+                - row.mach
             )
         result = df.assign(base=base_load)
         return result


### PR DESCRIPTION
Currently the report table does not correct the baseload for machine usage as I believe should be the case.
I tested this fix and it seems to work.