### PR TITLE
fix: remove incorrect AC-power cap on DC-side discharge variable

### DIFF
--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -3121,8 +3121,9 @@ class DaCalc(DaBase):
         model.max_nodes = 1500
         # model.max_seconds = 20
         if self.log_level > logging.DEBUG:
-            model.verbose = 0
-        model.check_optimization_results()
+            model.verbose = 1
+        model.threads = -1 #use all available cores
+        # model.check_optimization_results()
 
         # kosten optimalisering
         if self.strategy == "minimize cost":

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -814,7 +814,7 @@ class DaCalc(DaBase):
         ]
         dc_to_ac = [
             [
-                model.add_var(var_type=CONTINUOUS, lb=0, ub=max_discharge_power[b])
+                model.add_var(var_type=CONTINUOUS, lb=0, ub=max(dc_to_ac_samples[b]) if dc_to_ac_samples[b] else 0)
                 for _ in range(U)
             ]
             for b in range(B)


### PR DESCRIPTION
fix: remove incorrect AC-power cap on DC-side discharge variable

dc_to_ac (DC power drawn by the inverter during battery discharge) was bounded by max_discharge_power`, the inverter's AC-rated max output.

Since DC input always exceeds AC output during discharge (DC = AC / eff), this bound was tighter than physically achievable and silently prevented the optimizer from ever reaching full-power discharge.

At a 6000 W / 92.5% discharge stage, the model could only ever draw up to 6.0 kW DC — capping delivered AC at 6.0 * 0.925 = 5.55 kW (1.39 kWh per 15-min interval) instead of the correct 6.0 kW / 1.50 kWh.

Bound now derives from the discharge efficiency curve itself

(max(dc_to_ac_samples[b])), matching the true DC power needed to reach rated AC output.

Plus:
added support to use all available cpu's