### PR TITLE
Add `flex cost` / `flex cost max` for machines

### DIFF
--- a/dao/prog/config/models/devices/machines.py
+++ b/dao/prog/config/models/devices/machines.py
@@ -4,7 +4,7 @@ Appliance/machine configuration models (washing machine, dishwasher, etc.).
 
 from typing import Optional
 from pydantic import BaseModel, Field, ConfigDict
-from ..base import EntityId
+from ..base import EntityId, FlexFloat
 
 
 class MachineProgram(BaseModel):
@@ -108,6 +108,38 @@ class MachineConfig(BaseModel):
             "x-help": "Optional: Home Assistant entity to force immediate start, bypassing optimization. Useful for urgent wash cycles.",
             "x-ui-section": "Machine Specifications",
             "x-ui-widget-filter": "input_boolean,switch,button"
+        }
+    )
+    flex_cost: FlexFloat = Field(
+        default=FlexFloat(value=0.0),
+        alias="flex cost",
+        description="Flex cost in euro per kwartier (15 min) that the start is delayed",
+        json_schema_extra={
+            "x-help": "Virtual cost in euro per kwartier (15 minutes) that the calculated start is "
+                      "delayed within the planning window. Makes the optimizer prefer an earlier start "
+                      "when the cost difference with a later start is small. Set to 0 to disable "
+                      "(machine starts purely on lowest cost, regardless of timing). Can be a fixed "
+                      "number or a Home Assistant entity ID (e.g. an input_number helper) so you can "
+                      "tune it live.",
+            "x-unit": "euro/kwartier delay",
+            "x-ui-section": "General",
+            "x-validation-hint": "Must be >= 0, typically 0.001 - 0.02 euro/kwartier"
+        }
+    )
+    flex_cost_max: FlexFloat = Field(
+        default=FlexFloat(value=0.0),
+        alias="flex cost max",
+        description="Maximum extra cost in euro to let this machine start as early as possible",
+        json_schema_extra={
+            "x-help": "Budget in euro. When set (> 0), the machine starts at the earliest possible "
+                      "time whose total cost does not exceed the cheapest possible cost plus this "
+                      "budget — i.e. 'start as early as possible, but never spend more than this much "
+                      "extra to do it'. Set to 0 to disable (machine starts purely on lowest cost, "
+                      "regardless of timing; 'flex cost' can still be used as a soft tie-breaker). "
+                      "Can be a fixed number or a Home Assistant entity ID.",
+            "x-unit": "euro",
+            "x-ui-section": "General",
+            "x-validation-hint": "Must be >= 0. 0 means disabled (only 'flex cost' applies, if set)."
         }
     )
     

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -2597,6 +2597,8 @@ class DaCalc(DaBase):
         ma_planned_start_dt = []  # start tijdstip planning window
         ma_planned_end_dt = []  # eind tijdstip planning window
         ma_instant_start = []  # direct starten
+        ma_flex_cost = []  # penalty in euro/kwartier vertraging t.o.v. het begin van de window
+        ma_flex_cost_max = []  # maximum totale flex cost in euro, 0 = geen maximum
         for m in range(M):
             error = False
             ma_name.append(self.machines[m].name)
@@ -2609,6 +2611,8 @@ class DaCalc(DaBase):
             ma_entity_plan_end.append(
                 self.machines[m].entity_calculated_end
             )
+            ma_flex_cost.append(self.machines[m].flex_cost.resolve(ha_getter))  # FlexFloat
+            ma_flex_cost_max.append(self.machines[m].flex_cost_max.resolve(ha_getter))  # FlexFloat
             entity_machine_program = self.machines[m].entity_selected_program
             if entity_machine_program:
                 try:
@@ -2872,6 +2876,22 @@ class DaCalc(DaBase):
             [model.add_var(var_type=BINARY) for _ in range(KW[m])] for m in range(M)
         ]
 
+        # flex cost per machine: penalty die oploopt naarmate de machine later in
+        # zijn planning-window start. Net als bij de EV switch_cost zorgt dit
+        # ervoor dat bij een klein verschil in kosten de machine toch eerder start.
+        flex_cost_ma = [model.add_var(var_type=CONTINUOUS, lb=0) for _ in range(M)]
+        for m in range(M):
+            if KW[m] == 0:
+                model += flex_cost_ma[m] == 0
+            else:
+                model += flex_cost_ma[m] == xsum(
+                    ma_flex_cost[m] * kw * ma_start[m][kw] for kw in range(KW[m])
+                )
+                # flex cost max: bovengrens op de extra kosten door de flex cost
+                # penalty. 0 (default) betekent geen maximum.
+                if ma_flex_cost_max[m] > 0:
+                    model += flex_cost_ma[m] <= ma_flex_cost_max[m]
+
         # machine aan per kwartier per run
         # ma_on = [[[model.add_var(var_type=BINARY) for kw in range(KW[m])]
         #           for r in range(R[m])] for m in range(M)]
@@ -3051,6 +3071,7 @@ class DaCalc(DaBase):
             xsum(c_l[u] * pl[u] - c_t[u] * pt[u] for u in range(U))
             + xsum(cycle_cost[b] + penalty_cost[b] for b in range(B))
             + xsum(switch_cost[e] for e in range(EV))
+            + xsum(flex_cost_ma[m] for m in range(M))
             + xsum(
                 (soc_mid[b][0] - soc_mid[b][U])
                 * one_soc[b]
@@ -3079,11 +3100,31 @@ class DaCalc(DaBase):
             model.verbose = 0
         model.check_optimization_results()
 
+        # extra kosten door de flex cost-voorkeur (zowel de zachte kwartier-
+        # penalty als een eventueel flex cost max budget) - alleen relevant
+        # bij strategie "minimize cost"
+        machine_flex_extra_cost = 0.0
+
         # kosten optimalisering
         if self.strategy == "minimize cost":
             strategie = "minimale kosten"
             logging.info(f"Strategie: {strategie}")
             logging.info(f"Maximale fout (maximal gap): {max_gap:<8.6f} euro")
+
+            flex_terms = xsum(flex_cost_ma[m] for m in range(M))
+
+            # baseline: de echt goedkoopste oplossing, zonder de flex cost-
+            # voorkeur voor eerder starten, puur om het effect ervan te
+            # kunnen rapporteren. Deze oplossing wordt niet gebruikt.
+            baseline_real_cost = None
+            if any(ma_flex_cost[m] > 0 or ma_flex_cost_max[m] > 0 for m in range(M)):
+                model.objective = minimize(cost - flex_terms)
+                model.optimize()
+                if model.num_solutions > 0:
+                    baseline_real_cost = cost.x - sum(
+                        flex_cost_ma[m].x for m in range(M)
+                    )
+
             model.objective = minimize(cost)
             start_calc = time.perf_counter()
             model.optimize()
@@ -3092,6 +3133,50 @@ class DaCalc(DaBase):
             if model.num_solutions == 0:
                 logging.warning(f"Geen oplossing voor: {self.strategy}")
                 return None
+
+            # machines met een flex cost max: binnen dat kostenbudget zo vroeg
+            # mogelijk starten (i.p.v. de goedkoopste toegestane starttijd).
+            ma_flex_early = [
+                m for m in range(M) if KW[m] > 0 and ma_flex_cost_max[m] > 0
+            ]
+            if ma_flex_early:
+                min_cost = cost.x
+                budget = sum(ma_flex_cost_max[m] for m in ma_flex_early)
+                model += cost <= min_cost + budget
+                model.objective = minimize(
+                    xsum(
+                        kw * ma_start[m][kw]
+                        for m in ma_flex_early
+                        for kw in range(KW[m])
+                    )
+                )
+                model.optimize()
+                if model.num_solutions == 0:
+                    logging.warning(
+                        "Geen oplossing bij herberekening voor zo vroeg mogelijk "
+                        "starten binnen flex cost max; val terug op goedkoopste "
+                        "oplossing"
+                    )
+                    model += cost <= min_cost
+                    model.objective = minimize(cost)
+                    model.optimize()
+                else:
+                    logging.info(
+                        f"Herberekening: machines zo vroeg mogelijk gestart "
+                        f"binnen budget van {budget:.2f} euro "
+                        f"(kosten na herberekening: {cost.x:.2f} euro, "
+                        f"was {min_cost:.2f} euro)"
+                    )
+
+            # echte extra kosten (in euro) door de flex cost-voorkeur, t.o.v.
+            # de goedkoopste oplossing zonder die voorkeur
+            if baseline_real_cost is not None:
+                final_real_cost = cost.x - sum(
+                    flex_cost_ma[m].x for m in range(M)
+                )
+                machine_flex_extra_cost = max(
+                    0.0, final_real_cost - baseline_real_cost
+                )
         elif self.strategy == "minimize consumption":
             strategie = "minimale levering"
             logging.info(f"Strategie: {strategie}")
@@ -3546,6 +3631,9 @@ class DaCalc(DaBase):
         total_switch_cost = 0
         for e in range(EV):
             total_switch_cost += switch_cost[e].x
+        total_flex_cost_ma = 0
+        for m in range(M):
+            total_flex_cost_ma += flex_cost_ma[m].x
         boiler_storage = (
             (boiler_temp[0].x - boiler_temp[U].x)
             * (spec_heat_boiler / (3600 * cop_boiler))
@@ -3557,6 +3645,7 @@ class DaCalc(DaBase):
             + total_cycle_cost
             + total_penalty_cost
             + total_switch_cost
+            + total_flex_cost_ma
             + battery_storage
             + boiler_storage
         )
@@ -3568,12 +3657,15 @@ class DaCalc(DaBase):
             f"Cycle cost         {total_cycle_cost: 7.2f}\n"
             f"Penalty cost       {total_penalty_cost: 7.2f}\n"
             f"EV switch costs    {total_switch_cost: 7.2f}\n"
+            f"Machine flex costs {total_flex_cost_ma: 7.2f}\n"
+            f"  waarvan zo vroeg mogelijk binnen budget: "
+            f"{machine_flex_extra_cost: 7.2f} "
+            f"(zit al in Cost consumption)\n"
             f"Battery storage    {battery_storage: 7.2f}\n"
             f"Boiler storage     {boiler_storage: 7.2f}\n"
             f"Profit production  {profit_production: 7.2f}\n"
             f"Total              {total_cost: 7.2f}\n"
-            f"Cost after optimize            {cost.x: 7.2f}\n"
-            f"Profit:                        {old_cost_da - cost.x: 7.2f}"
+            f"Cost after optimize            {cost.x: 7.2f}\n"            f"Profit:                        {old_cost_da - cost.x: 7.2f}"
         )
 
         # doorzetten van alle settings naar HA


### PR DESCRIPTION
### What
Adds two new optional settings per machine, analogous to the EV `switch cost`:

- **`flex cost`** (`FlexFloat`, default `0.0`): a virtual cost in euro per kwartier (15 min) that the calculated start is delayed within the planning window. Makes the optimizer prefer an earlier start when the price difference with a later start is small. `0` = disabled (current behaviour, unchanged).
- **`flex cost max`** (`FlexFloat`, default `0.0`): a budget in euro. When set (`> 0`), the machine starts at the *earliest* possible time whose total cost does not exceed the cheapest possible cost plus this budget — i.e. "start as early as possible, but never spend more than this much extra to do it". `0` = disabled.

Both settings accept either a fixed number or a Home Assistant entity ID (e.g. an `input_number` helper), so they can be tuned live from HA without editing the config.

### Why
For machines (unlike EVs), the optimizer currently has no tie-breaking preference: if several start times are equally (or almost equally) cheap, it can pick an arbitrarily late one. This adds a configurable, opt-in nudge toward earlier starts, with a hard cap on how much that preference is allowed to cost.

### How it works
- `flex cost` is added as a small linear penalty term in the "minimize cost" objective, proportional to how many kwartieren into the planning window the machine starts.
- `flex cost max`, when set, triggers a second (lexicographic) optimization pass: after the normal cheapest solution is found, the model is re-solved to minimize start time (earliness) subject to total cost staying within `min_cost + flex cost max`.
- To report the real monetary impact of these settings (not just the synthetic penalty value, which is misleadingly `0` whenever the machine ends up starting at the very first kwartier), a baseline solve without any flex preference is done first purely for comparison. The log now shows the actual extra euros spent due to the flex preference, e.g.:
  ```
  Machine flex costs    0.05
    waarvan zo vroeg mogelijk binnen budget:    0.03 (zit al in Cost consumption)
  ```

### Compatibility
- Both new fields default to `0.0`, so existing configs are unaffected until explicitly set.
- Only the "minimize cost" strategy is affected; "minimize consumption" is unchanged.
- `SETTINGS.md` and `config_schema.json` were not regenerated as I don't know how to do that properly

### Testing
- Verified via small standalone MIP models that:
  - `flex cost` correctly favours an earlier start only when the price difference is smaller than the penalty, and still picks a genuinely cheaper later start when the difference is large.
  - `flex cost max` picks the *earliest* start whose cost is within budget (not just the cheapest one within budget).
  - The new "extra cost" reporting is non-zero and accurate even when the flex-preferred start lands on kwartier 0.
- Ran the full optimizer against a real-world config with these settings enabled; no regressions in EV/battery/boiler scheduling observed.
