### PR TITLE
Preload next grid setpoint before optimization run

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -403,6 +403,7 @@ Optimizer ensures combined consumption never exceeds this limit:
 | `max_power` | number | No | `17` | Maximum grid power in kW (Unit: `kW`) _Must be > 0, typical 7-25 kW for residential_ |
 | `entity balance switch` | [EntityId](#entityid) (optional) | No | `null` | HA entity for grid balancing switch |
 | `entity grid setpoint` | [EntityId](#entityid) (optional) | No | `null` | HA entity for the grid setpoint |
+| `preload next interval controls` | boolean | No | `true` | Restore cached battery and EV controls at the start of the next interval |
 
 <details>
 <summary><b>📖 Field Details</b> (click to expand)</summary>
@@ -418,6 +419,10 @@ Optional: Home Assistant entity to enable/disable grid balancing mode. Used for 
 **`entity grid setpoint`**
 
 Optional: Home Assistant entity to save the average calculated power on the grid-point. Can be used for XOM-regulation.
+
+**`preload next interval controls`**
+
+Optional: cache the calculated battery feed-in values and EV charging amperes for the next interval and restore them exactly when that next interval starts. Disable this if you do not want DAO to preload these controls before a new optimization run has finished.
 
 </details>
 

--- a/dao/DOCS.md
+++ b/dao/DOCS.md
@@ -573,6 +573,7 @@ Ga je hier voor de eerste keer mee aan gang volg dan de volgende aanpak:
   * strategy: minimize cost
   * notifications bij opstarten en berekening: false
   * grid, max_power: 17 kW (komt overeen met 3 x 25 A)
+  * grid, preload next interval controls: true
   * dashboard, port: 5000
 * laat de rest "blanko" 
   * boiler, boiler present false
@@ -617,6 +618,13 @@ Daar zijn m.i.v. 2025.11.2 de volgende bijgekomen:
 
 Vanaf versie 2025.12.0 is daar bijgekomen:
 - boiler setting: heating allowed below
+
+#### Preload next interval controls
+Met de optie `grid -> preload next interval controls` kan DAO de berekende instellingen voor het volgende interval alvast bewaren in een JSON-bestand. Bij het begin van dat volgende kwartier of uur kan DAO dan, nog voordat de nieuwe optimalisatie klaar is, alvast de berekende aansturing zetten voor:
+- batterijen: het berekende feed-in/laad- of ontlaadvermogen en de operating mode
+- EV's: de berekende laadampere
+
+DAO gebruikt deze cache alleen als het opgeslagen interval exact overeenkomt met het interval dat net is gestart. Zo wordt voorkomen dat verouderde cache-waarden later alsnog worden toegepast.
 
 
 Enkele voorbeelden (van het gebruik van flex setting): 

--- a/dao/data/options_example.json
+++ b/dao/data/options_example.json
@@ -105,7 +105,8 @@
   },
   "grid": {
     "max_power": 17,
-    "entity balance switch": "input_boolean.balanceer_grid"
+    "entity balance switch": "input_boolean.balanceer_grid",
+    "preload next interval controls": true
   },
   "history": {
     "save days": 7

--- a/dao/prog/config/models/grid.py
+++ b/dao/prog/config/models/grid.py
@@ -43,7 +43,7 @@ class GridConfig(BaseModel):
         },
     )
     preload_next_interval_controls: bool = Field(
-        default=True,
+        default=False,
         alias="preload next interval controls",
         description="Restore cached battery and EV controls at the start of the next interval",
         json_schema_extra={

--- a/dao/prog/config/models/grid.py
+++ b/dao/prog/config/models/grid.py
@@ -42,6 +42,16 @@ class GridConfig(BaseModel):
             "x-ui-section": "Power Configuration",
         },
     )
+    preload_next_interval_controls: bool = Field(
+        default=True,
+        alias="preload next interval controls",
+        description="Restore cached battery and EV controls at the start of the next interval",
+        json_schema_extra={
+            "x-help": "Optional: apply cached battery feed-in values and EV charging amperes for the exact start of the next interval before a new optimization finishes.",
+            "x-ui-section": "Power Configuration",
+            "x-ui-widget-filter": "switch",
+        },
+    )
 
     model_config = ConfigDict(
         extra="allow",

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -140,11 +140,15 @@ class DaCalc(DaBase):
             except Exception as ex:
                 logging.warning(f"Kon preload voor EV niet toepassen: {ex}")
 
+        battery_summary, ev_summary = self._format_next_interval_controls_for_log(
+            applied_battery_controls,
+            applied_ev_controls,
+        )
         logging.info(
-            "Vooraf berekende instellingen toegepast voor %s | batterijen=%s | ev=%s",
+            "Vooraf berekende instellingen toegepast voor %s | batterijen=[%s] | ev=[%s]",
             interval_start_str,
-            json.dumps(applied_battery_controls, ensure_ascii=True),
-            json.dumps(applied_ev_controls, ensure_ascii=True),
+            battery_summary,
+            ev_summary,
         )
 
     def _get_primary_battery_options(self):
@@ -191,7 +195,12 @@ class DaCalc(DaBase):
             )
         ev_parts = []
         for control in ev_controls:
-            ev_parts.append(f"EV{control['index']}: {control['ampere']}A")
+            ev_part = f"EV{control['index']}: {control['ampere']}A"
+            if "applied" in control:
+                ev_part += ", toegepast=" + ("ja" if control["applied"] else "nee")
+            if control.get("reason"):
+                ev_part += f", reden={control['reason']}"
+            ev_parts.append(ev_part)
 
         battery_summary = ", ".join(battery_parts) if battery_parts else "geen"
         ev_summary = ", ".join(ev_parts) if ev_parts else "geen"
@@ -3970,11 +3979,15 @@ class DaCalc(DaBase):
                     "battery_controls": battery_controls,
                     "ev_controls": ev_controls,
                 }
+                battery_summary, ev_summary = self._format_next_interval_controls_for_log(
+                    battery_controls,
+                    ev_controls,
+                )
                 logging.info(
-                    "Vooraf berekende instellingen gecached voor %s | batterijen=%s | ev=%s",
+                    "Vooraf berekende instellingen gecached voor %s | batterijen=[%s] | ev=[%s]",
                     next_interval_dt.strftime("%Y-%m-%d %H:%M:%S"),
-                    json.dumps(battery_controls, ensure_ascii=True),
-                    json.dumps(ev_controls, ensure_ascii=True),
+                    battery_summary,
+                    ev_summary,
                 )
             #####################################
 

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -6,9 +6,11 @@ Zie verder: DOCS.md
 
 import datetime
 import datetime as dt
+import json
 import time
 import sys
 import math
+from pathlib import Path
 import pandas as pd
 from mip import Model, xsum, minimize, BINARY, CONTINUOUS, INTEGER
 from pandas.core.dtypes.inference import is_number
@@ -25,6 +27,9 @@ from dao.prog.da_base import DaBase
 
 
 class DaCalc(DaBase):
+    _next_grid_set_point_cache: int | None = None
+    _next_grid_set_point_cache_file = Path("../data/next_grid_set_point_cache.json")
+
     def __init__(self, file_name=None):
         super().__init__(file_name=file_name)
         if self.config is None:
@@ -49,6 +54,79 @@ class DaCalc(DaBase):
         self.machines = self.config.machines
         # self.start_logging()
 
+    def restore_next_grid_set_point(self):
+        """Push the precomputed next grid setpoint back to HA before a new run starts."""
+        if self.debug:
+            return
+
+        entity_id = self._resolve_grid_setpoint_entity_id()
+        if entity_id is None:
+            logging.info(
+                "Geen entity set power feedin geconfigureerd; vooraf berekende grid set point niet toegepast"
+            )
+            return
+
+        set_point = DaCalc._next_grid_set_point_cache
+        source = "geheugen"
+
+        if set_point is None:
+            set_point = self._load_next_grid_set_point_cache()
+            source = "bestand"
+
+        if set_point is None:
+            logging.info("Geen vooraf berekende grid set point beschikbaar; HA niet aangepast")
+            return
+
+        DaCalc._next_grid_set_point_cache = set_point
+        self.set_value(entity_id, set_point)
+        logging.info(
+            f"Vooraf berekende grid set point direct naar HA gezet ({source}): {set_point} W"
+        )
+
+    def _get_primary_battery_options(self):
+        if self.battery_options is None:
+            return None
+        if isinstance(self.battery_options, list) and len(self.battery_options) > 0:
+            return self.battery_options[0]
+        return self.battery_options
+
+    def _resolve_grid_setpoint_entity_id(self):
+        battery_options = self._get_primary_battery_options()
+        return self._get_option("entity_set_power_feedin", battery_options)
+
+    def _load_next_grid_set_point_cache(self) -> int | None:
+        cache_file = DaCalc._next_grid_set_point_cache_file
+        if not cache_file.exists():
+            return None
+
+        try:
+            cache_data = json.loads(cache_file.read_text(encoding="utf-8"))
+            set_point = cache_data.get("set_point")
+            if set_point is None:
+                return None
+            return int(set_point)
+        except Exception as ex:
+            logging.warning(
+                f"Kon vooraf berekende grid set point niet lezen uit cachebestand ({cache_file}): {ex}"
+            )
+            return None
+
+    def _store_next_grid_set_point_cache(self, set_point: int) -> None:
+        cache_file = DaCalc._next_grid_set_point_cache_file
+        cache_payload = {
+            "set_point": int(set_point),
+            "stored_at": dt.datetime.now().isoformat(timespec="seconds"),
+        }
+        try:
+            cache_file.write_text(
+                json.dumps(cache_payload, ensure_ascii=True),
+                encoding="utf-8",
+            )
+        except Exception as ex:
+            logging.warning(
+                f"Kon vooraf berekende grid set point niet opslaan in cachebestand ({cache_file}): {ex}"
+            )
+
     def calc_optimum(
         self,
         _start_dt: dt.datetime | None = None,
@@ -61,6 +139,7 @@ class DaCalc(DaBase):
         if _start_dt is not None or _start_soc is not None or _start_ev_soc is not None:
             self.debug = True
         logging.info(f"Debug = {self.debug}")
+        self.restore_next_grid_set_point()
         # Callable passed to FlexValue.resolve() — returns HA state as a plain string.
         ha_getter = lambda eid: self.get_state(eid).state
         if _start_dt is None:
@@ -3713,13 +3792,25 @@ class DaCalc(DaBase):
                 logging.info(f"Grid balanceren: {balance_state}")
             grid_set_point = round(1000 * (c_l[0].x - c_t[0].x) / hour_fraction[0], 0)
             logging.info(f"Grid set point: {grid_set_point} W")
+            next_grid_set_point = grid_set_point
+            if U > 1:
+                next_grid_set_point = round(
+                    1000 * (c_l[1].x - c_t[1].x) / hour_fraction[1], 0
+                )
             if not self.debug:
                 # export the ess grid setpoint in W
-                self.set_entity_value(
-                    "entity_grid_setpoint",
-                    self.grid,
-                    grid_set_point,
-                )
+                setpoint_entity_id = self._resolve_grid_setpoint_entity_id()
+                if setpoint_entity_id is not None:
+                    self.set_value(setpoint_entity_id, grid_set_point)
+                else:
+                    logging.info(
+                        "Geen grid setpoint-entity geconfigureerd; setpoint niet naar HA geschreven"
+                    )
+            DaCalc._next_grid_set_point_cache = int(next_grid_set_point)
+            self._store_next_grid_set_point_cache(DaCalc._next_grid_set_point_cache)
+            logging.info(
+                f"Volgende vooraf berekende grid set point gecached: {DaCalc._next_grid_set_point_cache} W"
+            )
             #####################################
 
             ###########################################

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -54,7 +54,7 @@ class DaCalc(DaBase):
         # self.start_logging()
 
     def _preload_next_interval_controls_enabled(self) -> bool:
-        return bool(getattr(self.grid, "preload_next_interval_controls", True))
+        return bool(getattr(self.grid, "preload_next_interval_controls", False))
 
     def restore_next_interval_controls(self, interval_start: dt.datetime):
         """Restore cached battery and EV controls for the exact next interval."""
@@ -68,7 +68,7 @@ class DaCalc(DaBase):
         interval_start_str = interval_start.strftime("%Y-%m-%d %H:%M:%S")
         if cache_data.get("interval_start") != interval_start_str:
             logging.info(
-                "Preload overgeslagen: cache hoort niet bij het huidige interval %s",
+                "Preload skipped: cache does not match current interval %s",
                 interval_start_str,
             )
             return
@@ -102,7 +102,7 @@ class DaCalc(DaBase):
                     }
                 )
             except Exception as ex:
-                logging.warning(f"Kon preload voor batterij niet toepassen: {ex}")
+                logging.warning(f"Failed to apply battery preload controls: {ex}")
 
         applied_ev_controls = []
         for ev_control in cache_data.get("ev_controls", []):
@@ -138,29 +138,18 @@ class DaCalc(DaBase):
                     }
                 )
             except Exception as ex:
-                logging.warning(f"Kon preload voor EV niet toepassen: {ex}")
+                logging.warning(f"Failed to apply EV preload controls: {ex}")
 
         battery_summary, ev_summary = self._format_next_interval_controls_for_log(
             applied_battery_controls,
             applied_ev_controls,
         )
         logging.info(
-            "Vooraf berekende instellingen toegepast voor %s | batterijen=[%s] | ev=[%s]",
+            "Precomputed controls applied for %s | batteries=[%s] | ev=[%s]",
             interval_start_str,
             battery_summary,
             ev_summary,
         )
-
-    def _get_primary_battery_options(self):
-        if self.battery_options is None:
-            return None
-        if isinstance(self.battery_options, list) and len(self.battery_options) > 0:
-            return self.battery_options[0]
-        return self.battery_options
-
-    def _resolve_grid_setpoint_entity_id(self):
-        battery_options = self._get_primary_battery_options()
-        return self._get_option("entity_set_power_feedin", battery_options)
 
     def _load_next_interval_controls_cache(self) -> dict | None:
         cache_file = DaCalc._next_interval_controls_cache_file
@@ -168,7 +157,7 @@ class DaCalc(DaBase):
             return json.loads(cache_file.read_text(encoding="utf-8"))
         except Exception as ex:
             logging.warning(
-                f"Kon preload-cache niet lezen uit cachebestand ({cache_file}): {ex}"
+                f"Failed to read preload cache from cache file ({cache_file}): {ex}"
             )
             return None
 
@@ -182,7 +171,7 @@ class DaCalc(DaBase):
             )
         except Exception as ex:
             logging.warning(
-                f"Kon preload-cache niet opslaan in cachebestand ({cache_file}): {ex}"
+                f"Failed to write preload cache to cache file ({cache_file}): {ex}"
             )
 
     def _format_next_interval_controls_for_log(
@@ -191,19 +180,19 @@ class DaCalc(DaBase):
         battery_parts = []
         for control in battery_controls:
             battery_parts.append(
-                f"B{control['index']}: {control['net_power']}W, modus={control['operating_mode']}, stop={control['stop_datetime']}"
+                f"B{control['index']}: {control['net_power']}W, mode={control['operating_mode']}, stop={control['stop_datetime']}"
             )
         ev_parts = []
         for control in ev_controls:
             ev_part = f"EV{control['index']}: {control['ampere']}A"
             if "applied" in control:
-                ev_part += ", toegepast=" + ("ja" if control["applied"] else "nee")
+                ev_part += ", applied=" + ("yes" if control["applied"] else "no")
             if control.get("reason"):
-                ev_part += f", reden={control['reason']}"
+                ev_part += f", reason={control['reason']}"
             ev_parts.append(ev_part)
 
-        battery_summary = ", ".join(battery_parts) if battery_parts else "geen"
-        ev_summary = ", ".join(ev_parts) if ev_parts else "geen"
+        battery_summary = ", ".join(battery_parts) if battery_parts else "none"
+        ev_summary = ", ".join(ev_parts) if ev_parts else "none"
         return battery_summary, ev_summary
 
     def calc_optimum(
@@ -3813,6 +3802,99 @@ class DaCalc(DaBase):
         logging.debug("\n")
 
         try:
+            next_interval_cache_payload = None
+
+            def _calculate_battery_control_for_interval(
+                battery_index: int,
+                interval_index: int,
+                interval_dt: dt.datetime,
+            ) -> tuple[int, str, dt.datetime | None]:
+                interval_grid_balance = (
+                    abs(c_l[interval_index].x - c_t[interval_index].x) <= 0.01
+                )
+                net_power = int(
+                    1000
+                    * (
+                        ac_to_dc[battery_index][interval_index].x
+                        - ac_from_dc[battery_index][interval_index].x
+                    )
+                )
+                minimum_power = int(self.battery_options[battery_index].minimum_power)
+                operating_mode = self.battery_options[
+                    battery_index
+                ].entity_set_operating_mode_on
+                stop_dt = None
+                soc_at_interval_start = soc[battery_index][interval_index].x
+
+                if abs(net_power) <= 20:
+                    net_power = 0
+                    operating_mode = self.battery_options[
+                        battery_index
+                    ].entity_set_operating_mode_off
+                elif interval_grid_balance:
+                    operating_mode = self.battery_options[
+                        battery_index
+                    ].entity_set_operating_mode_on
+                elif (
+                    minimum_power > 0
+                    and abs(net_power) < minimum_power
+                    and self.battery_options[battery_index].entity_stop_inverter
+                    is not None
+                    and (
+                        len(reduce_power_low_soc[battery_index]) == 0
+                        or soc_at_interval_start
+                        > reduce_power_low_soc[battery_index][
+                            len(reduce_power_low_soc[battery_index]) - 1
+                        ]["soc"]
+                    )
+                    and (
+                        len(reduce_power_high_soc[battery_index]) == 0
+                        or soc_at_interval_start
+                        < reduce_power_high_soc[battery_index][0]["soc"]
+                    )
+                ):
+                    stop_dt = dt.datetime.fromtimestamp(
+                        int(
+                            interval_dt.timestamp()
+                            + (abs(net_power) / minimum_power) * self.interval_s
+                        )
+                    )
+                    net_power = minimum_power if net_power > 0 else -minimum_power
+                elif ac_to_dc[battery_index][interval_index].x > 0.0:
+                    net_power = round(
+                        sum(
+                            ac_to_dc_w[battery_index][interval_index][cs].x
+                            * charge_stages[battery_index][cs]["power"]
+                            for cs in range(CS[battery_index])
+                            if ac_to_dc_w[battery_index][interval_index][cs].x > 0
+                        )
+                    )
+                elif ac_from_dc[battery_index][interval_index].x > 0.0:
+                    net_power = -round(
+                        sum(
+                            ac_from_dc_w[battery_index][interval_index][ds].x
+                            * discharge_stages[battery_index][ds]["power"]
+                            for ds in range(DS[battery_index])
+                            if ac_from_dc_w[battery_index][interval_index][ds].x > 0
+                        )
+                    )
+
+                return net_power, operating_mode, stop_dt
+
+            def _calculate_ev_ampere_for_interval(
+                ev_index: int,
+                interval_index: int,
+            ) -> tuple[int, float]:
+                if ready_u[ev_index] < interval_index:
+                    return 0, 0.0
+
+                for cs in range(ECS[ev_index])[1:]:
+                    stage_value = stage_factor[ev_index][cs][interval_index].x
+                    if stage_value > 0:
+                        return ev_charge_stages[ev_index][cs]["ampere"], stage_value
+
+                return 0, 0.0
+
             if self.boiler_present:
                 if float(c_b[0].x) > 0.0:
                     if self.debug:
@@ -3871,79 +3953,28 @@ class DaCalc(DaBase):
                 logging.info(f"Grid balanceren: {balance_state}")
             grid_set_point = round(1000 * (c_l[0].x - c_t[0].x) / hour_fraction[0], 0)
             logging.info(f"Grid set point: {grid_set_point} W")
-            next_grid_set_point = grid_set_point
-            if U > 1:
-                next_grid_set_point = round(
-                    1000 * (c_l[1].x - c_t[1].x) / hour_fraction[1], 0
-                )
-            if U > 1:
-                logging.info(
-                    "Verwachte grid set point volgend interval (%s): %s W",
-                    tijd[1].strftime("%Y-%m-%d %H:%M:%S"),
-                    next_grid_set_point,
-                )
+            next_grid_set_point = round(
+                1000 * (c_l[1].x - c_t[1].x) / hour_fraction[1], 0
+            )
+            logging.info(
+                "Verwachte grid set point volgend interval (%s): %s W",
+                tijd[1].strftime("%Y-%m-%d %H:%M:%S"),
+                next_grid_set_point,
+            )
             if not self.debug:
-                # export the ess grid setpoint in W
-                setpoint_entity_id = self._resolve_grid_setpoint_entity_id()
-                if setpoint_entity_id is not None:
-                    logging.info(
-                        "HA write (bron=grid_set_point_huidig): %s W -> %s",
-                        grid_set_point,
-                        setpoint_entity_id,
-                    )
-                    self.set_value(setpoint_entity_id, grid_set_point)
-                else:
-                    logging.info(
-                        "Geen grid setpoint-entity geconfigureerd; setpoint niet naar HA geschreven"
-                    )
+                self.set_entity_value("entity grid setpoint", self.grid, grid_set_point)
             if not self.debug and self._preload_next_interval_controls_enabled():
-                next_interval_cache_payload = None
                 next_interval_index = 1
                 next_interval_dt = tijd[next_interval_index]
                 battery_controls = []
                 for b in range(B):
-                    next_grid_balance = abs(c_l[next_interval_index].x - c_t[next_interval_index].x) <= 0.01
-                    net_power = int(
-                        1000
-                        * (ac_to_dc[b][next_interval_index].x - ac_from_dc[b][next_interval_index].x)
+                    net_power, operating_mode, stop_dt = (
+                        _calculate_battery_control_for_interval(
+                            b,
+                            next_interval_index,
+                            next_interval_dt,
+                        )
                     )
-                    minimum_power = int(self.battery_options[b].minimum_power)
-                    operating_mode = self.battery_options[b].entity_set_operating_mode_on
-                    stop_dt = None
-                    soc_at_interval_start = soc[b][next_interval_index].x
-                    if abs(net_power) <= 20:
-                        net_power = 0
-                        operating_mode = self.battery_options[b].entity_set_operating_mode_off
-                    elif not next_grid_balance and minimum_power > 0 and abs(net_power) < minimum_power and self.battery_options[b].entity_stop_inverter is not None and (
-                        len(reduce_power_low_soc[b]) == 0
-                        or soc_at_interval_start > reduce_power_low_soc[b][len(reduce_power_low_soc[b]) - 1]["soc"]
-                    ) and (
-                        len(reduce_power_high_soc[b]) == 0
-                        or soc_at_interval_start < reduce_power_high_soc[b][0]["soc"]
-                    ):
-                        stop_dt = dt.datetime.fromtimestamp(
-                            int(
-                                next_interval_dt.timestamp()
-                                + (abs(net_power) / minimum_power) * self.interval_s
-                            )
-                        )
-                        net_power = minimum_power if net_power > 0 else -minimum_power
-                    elif ac_to_dc[b][next_interval_index].x > 0.0:
-                        net_power = round(
-                            sum(
-                                ac_to_dc_w[b][next_interval_index][cs].x * charge_stages[b][cs]["power"]
-                                for cs in range(CS[b])
-                                if ac_to_dc_w[b][next_interval_index][cs].x > 0
-                            )
-                        )
-                    elif ac_from_dc[b][next_interval_index].x > 0.0:
-                        net_power = -round(
-                            sum(
-                                ac_from_dc_w[b][next_interval_index][ds].x * discharge_stages[b][ds]["power"]
-                                for ds in range(DS[b])
-                                if ac_from_dc_w[b][next_interval_index][ds].x > 0
-                            )
-                        )
                     battery_controls.append(
                         {
                             "index": b,
@@ -3959,12 +3990,10 @@ class DaCalc(DaBase):
 
                 ev_controls = []
                 for e in range(EV):
-                    ampere = 0
-                    if ready_u[e] >= next_interval_index:
-                        for cs in range(ECS[e])[1:]:
-                            if stage_factor[e][cs][next_interval_index].x > 0:
-                                ampere = ev_charge_stages[e][cs]["ampere"]
-                                break
+                    ampere, _ = _calculate_ev_ampere_for_interval(
+                        e,
+                        next_interval_index,
+                    )
                     ev_controls.append({"index": e, "ampere": ampere})
 
                 self._store_next_interval_controls_cache(
@@ -3984,7 +4013,7 @@ class DaCalc(DaBase):
                     ev_controls,
                 )
                 logging.info(
-                    "Vooraf berekende instellingen gecached voor %s | batterijen=[%s] | ev=[%s]",
+                    "Precomputed controls cached for %s | batteries=[%s] | ev=[%s]",
                     next_interval_dt.strftime("%Y-%m-%d %H:%M:%S"),
                     battery_summary,
                     ev_summary,
@@ -4073,28 +4102,23 @@ class DaCalc(DaBase):
                     entity_stop_laden = self.ev_options[e].entity_stop_charging
                 old_switch_state = self.get_state(entity_charge_switch).state
                 old_ampere_state = self.get_state(entity_charging_ampere).state
-                new_ampere_state = 0
-                new_switch_state = "off"
+                new_ampere_state, first_stage_factor = _calculate_ev_ampere_for_interval(
+                    e,
+                    0,
+                )
+                new_switch_state = "on" if new_ampere_state > 0 else "off"
                 new_state_stop_laden = None  # "2000-01-01 00:00:00"
 
                 line = "  ".join(
                     f"{stage_factor[e][cs][0].x:.2f}" for cs in range(ECS[e])[1:]
                 )
                 logging.debug(line)
-                for cs in range(ECS[e])[1:]:
-                    if stage_factor[e][cs][0].x > 0:
-                        new_ampere_state = ev_charge_stages[e][cs]["ampere"]
-                        if new_ampere_state > 0:
-                            new_switch_state = "on"
-                        if (stage_factor[e][cs][0].x < 1) and (
-                            energy_needed[e] > (ev_accu_in[e][0].x + 0.01)
-                        ):
-                            new_ts = (
-                                start_dt.timestamp() + stage_factor[e][cs][0].x * 3600
-                            )
-                            stop_laden = dt.datetime.fromtimestamp(int(new_ts))
-                            new_state_stop_laden = stop_laden.strftime("%Y-%m-%d %H:%M")
-                        break
+                if (first_stage_factor > 0) and (first_stage_factor < 1) and (
+                    energy_needed[e] > (ev_accu_in[e][0].x + 0.01)
+                ):
+                    new_ts = start_dt.timestamp() + first_stage_factor * 3600
+                    stop_laden = dt.datetime.fromtimestamp(int(new_ts))
+                    new_state_stop_laden = stop_laden.strftime("%Y-%m-%d %H:%M")
                 ev_name = self.ev_options[e].name
                 logging.info(f"Berekeningsuitkomst voor opladen van {ev_name}:")
                 logging.info(
@@ -4212,74 +4236,11 @@ class DaCalc(DaBase):
             ############################################
             for b in range(B):
                 # vermogen aan ac kant
-                netto_vermogen_bat = int(1000 * (ac_to_dc[b][0].x - ac_from_dc[b][0].x))
-                minimum_power = int(self.battery_options[b].minimum_power)
-                battery_state_on_value = self.battery_options[
-                    b
-                ].entity_set_operating_mode_on
-                battery_state_off_value = self.battery_options[
-                    b
-                ].entity_set_operating_mode_off
+                netto_vermogen_bat, new_state, stop_omvormer = (
+                    _calculate_battery_control_for_interval(b, 0, start_dt)
+                )
                 bat_name = self.battery_options[b].name
                 stop_inverter_id = self.battery_options[b].entity_stop_inverter
-                if abs(netto_vermogen_bat) <= 20:
-                    netto_vermogen_bat = 0
-                    new_state = battery_state_off_value
-                    stop_omvormer = None
-                elif grid_balance:
-                    new_state = battery_state_on_value
-                    stop_omvormer = None
-                elif (
-                    minimum_power > 0
-                    and abs(netto_vermogen_bat) < minimum_power
-                    and stop_inverter_id is not None
-                    and (
-                        len(reduce_power_low_soc[b]) == 0
-                        or start_soc[b]
-                        > reduce_power_low_soc[b][len(reduce_power_low_soc[b]) - 1]["soc"]
-                    )
-                    and (
-                        len(reduce_power_high_soc[b]) == 0
-                        or start_soc[b] < reduce_power_high_soc[b][0]["soc"]
-                    )
-                ):
-                    new_state = battery_state_on_value
-                    new_ts = (
-                        start_dt.timestamp()
-                        + (abs(netto_vermogen_bat) / minimum_power) * self.interval_s
-                    )
-                    stop_omvormer = dt.datetime.fromtimestamp(int(new_ts))
-                    if netto_vermogen_bat > 0:
-                        netto_vermogen_bat = minimum_power
-                    else:
-                        netto_vermogen_bat = -minimum_power
-                elif ac_to_dc[b][0].x > 0.0:  # laden met optimaal vermogen
-                    sum_weight_factor = 0
-                    sum_power = 0  # in W
-                    for cs in range(CS[b]):
-                        wf = ac_to_dc_w[b][0][cs].x
-                        if wf > 0:
-                            sum_weight_factor += wf
-                            sum_power += wf * charge_stages[b][cs]["power"]
-                    if sum_power > 0:
-                        new_state = battery_state_on_value
-                        netto_vermogen_bat = round(sum_power)
-                    stop_omvormer = None
-                elif ac_from_dc[b][0].x > 0.0:  # ontladen met optimaal vermogen
-                    sum_weight_factor = 0
-                    sum_power = 0  # in W
-                    for ds in range(DS[b]):
-                        wf = ac_from_dc_w[b][0][ds].x
-                        if wf > 0:
-                            sum_weight_factor += wf
-                            sum_power += wf * discharge_stages[b][ds]["power"]
-                    if sum_power > 0:
-                        new_state = battery_state_on_value
-                        netto_vermogen_bat = -round(sum_power)
-                    stop_omvormer = None
-                else:
-                    new_state = battery_state_on_value
-                    stop_omvormer = None
                 if stop_omvormer is not None and stop_inverter_id is None:
                     stop_omvormer = None
                 if stop_omvormer is None:
@@ -4522,7 +4483,7 @@ class DaCalc(DaBase):
                     )
                 )
                 logging.info(
-                    "Eindstatus cache volgend %s %s | batterijen: %s | ev: %s",
+                    "Final cache state for next %s %s | batteries: %s | ev: %s",
                     self.interval_name,
                     next_interval_cache_payload["interval_start"],
                     battery_summary,

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -27,8 +27,7 @@ from dao.prog.da_base import DaBase
 
 
 class DaCalc(DaBase):
-    _next_grid_set_point_cache: int | None = None
-    _next_grid_set_point_cache_file = Path("../data/next_grid_set_point_cache.json")
+    _next_interval_controls_cache_file = Path("../data/next_interval_controls.json")
 
     def __init__(self, file_name=None):
         super().__init__(file_name=file_name)
@@ -54,34 +53,69 @@ class DaCalc(DaBase):
         self.machines = self.config.machines
         # self.start_logging()
 
-    def restore_next_grid_set_point(self):
-        """Push the precomputed next grid setpoint back to HA before a new run starts."""
-        if self.debug:
+    def _preload_next_interval_controls_enabled(self) -> bool:
+        return bool(getattr(self.grid, "preload_next_interval_controls", True))
+
+    def restore_next_interval_controls(self, interval_start: dt.datetime):
+        """Restore cached battery and EV controls for the exact next interval."""
+        if self.debug or not self._preload_next_interval_controls_enabled():
             return
 
-        entity_id = self._resolve_grid_setpoint_entity_id()
-        if entity_id is None:
+        cache_data = self._load_next_interval_controls_cache()
+        if cache_data is None:
+            return
+
+        interval_start_str = interval_start.strftime("%Y-%m-%d %H:%M:%S")
+        if cache_data.get("interval_start") != interval_start_str:
             logging.info(
-                "Geen entity set power feedin geconfigureerd; vooraf berekende grid set point niet toegepast"
+                "Preload overgeslagen: cache hoort niet bij het huidige interval %s",
+                interval_start_str,
             )
             return
 
-        set_point = DaCalc._next_grid_set_point_cache
-        source = "geheugen"
+        for battery_control in cache_data.get("battery_controls", []):
+            try:
+                battery_options = self.battery_options[battery_control["index"]]
+                self.set_entity_value(
+                    "entity set power feedin",
+                    battery_options,
+                    battery_control["net_power"],
+                )
+                self.set_entity_option(
+                    "entity set operating mode",
+                    battery_options,
+                    battery_control["operating_mode"],
+                )
+                if battery_options.entity_stop_inverter is not None:
+                    self.call_service(
+                        "set_datetime",
+                        entity_id=battery_options.entity_stop_inverter,
+                        datetime=battery_control["stop_datetime"],
+                    )
+            except Exception as ex:
+                logging.warning(f"Kon preload voor batterij niet toepassen: {ex}")
 
-        if set_point is None:
-            set_point = self._load_next_grid_set_point_cache()
-            source = "bestand"
+        for ev_control in cache_data.get("ev_controls", []):
+            try:
+                ev_options = self.ev_options[ev_control["index"]]
+                if (
+                    self.get_state(ev_options.entity_plugged_in).state != "on"
+                    or self.get_state(ev_options.entity_position).state != "home"
+                ):
+                    continue
+                if float(ev_control["ampere"]) > 0:
+                    self.set_value(
+                        ev_options.entity_set_charging_ampere,
+                        ev_control["ampere"],
+                    )
+                    self.turn_on(ev_options.charge_switch)
+                else:
+                    self.set_value(ev_options.entity_set_charging_ampere, 0)
+                    self.turn_off(ev_options.charge_switch)
+            except Exception as ex:
+                logging.warning(f"Kon preload voor EV niet toepassen: {ex}")
 
-        if set_point is None:
-            logging.info("Geen vooraf berekende grid set point beschikbaar; HA niet aangepast")
-            return
-
-        DaCalc._next_grid_set_point_cache = set_point
-        self.set_value(entity_id, set_point)
-        logging.info(
-            f"Vooraf berekende grid set point direct naar HA gezet ({source}): {set_point} W"
-        )
+        logging.info("Vooraf berekende batterij- en EV-instellingen toegepast voor %s", interval_start_str)
 
     def _get_primary_battery_options(self):
         if self.battery_options is None:
@@ -94,29 +128,18 @@ class DaCalc(DaBase):
         battery_options = self._get_primary_battery_options()
         return self._get_option("entity_set_power_feedin", battery_options)
 
-    def _load_next_grid_set_point_cache(self) -> int | None:
-        cache_file = DaCalc._next_grid_set_point_cache_file
-        if not cache_file.exists():
-            return None
-
+    def _load_next_interval_controls_cache(self) -> dict | None:
+        cache_file = DaCalc._next_interval_controls_cache_file
         try:
-            cache_data = json.loads(cache_file.read_text(encoding="utf-8"))
-            set_point = cache_data.get("set_point")
-            if set_point is None:
-                return None
-            return int(set_point)
+            return json.loads(cache_file.read_text(encoding="utf-8"))
         except Exception as ex:
             logging.warning(
-                f"Kon vooraf berekende grid set point niet lezen uit cachebestand ({cache_file}): {ex}"
+                f"Kon preload-cache niet lezen uit cachebestand ({cache_file}): {ex}"
             )
             return None
 
-    def _store_next_grid_set_point_cache(self, set_point: int) -> None:
-        cache_file = DaCalc._next_grid_set_point_cache_file
-        cache_payload = {
-            "set_point": int(set_point),
-            "stored_at": dt.datetime.now().isoformat(timespec="seconds"),
-        }
+    def _store_next_interval_controls_cache(self, cache_payload: dict) -> None:
+        cache_file = DaCalc._next_interval_controls_cache_file
         try:
             cache_file.write_text(
                 json.dumps(cache_payload, ensure_ascii=True),
@@ -124,7 +147,7 @@ class DaCalc(DaBase):
             )
         except Exception as ex:
             logging.warning(
-                f"Kon vooraf berekende grid set point niet opslaan in cachebestand ({cache_file}): {ex}"
+                f"Kon preload-cache niet opslaan in cachebestand ({cache_file}): {ex}"
             )
 
     def calc_optimum(
@@ -139,7 +162,6 @@ class DaCalc(DaBase):
         if _start_dt is not None or _start_soc is not None or _start_ev_soc is not None:
             self.debug = True
         logging.info(f"Debug = {self.debug}")
-        self.restore_next_grid_set_point()
         # Callable passed to FlexValue.resolve() — returns HA state as a plain string.
         ha_getter = lambda eid: self.get_state(eid).state
         if _start_dt is None:
@@ -158,6 +180,7 @@ class DaCalc(DaBase):
             self.interval_s * math.floor(start_ts / self.interval_s)
         )
         start_interval_dt = datetime.datetime.fromtimestamp(start_interval_ts)
+        self.restore_next_interval_controls(start_interval_dt)
         # loopt af van 1 (starts_ds == start_interval) naar
         # 0 (start_interval is bijna bij begin volgend interval)
         interval_fraction_first_interval = (
@@ -3806,11 +3829,87 @@ class DaCalc(DaBase):
                     logging.info(
                         "Geen grid setpoint-entity geconfigureerd; setpoint niet naar HA geschreven"
                     )
-            DaCalc._next_grid_set_point_cache = int(next_grid_set_point)
-            self._store_next_grid_set_point_cache(DaCalc._next_grid_set_point_cache)
-            logging.info(
-                f"Volgende vooraf berekende grid set point gecached: {DaCalc._next_grid_set_point_cache} W"
-            )
+            if not self.debug and self._preload_next_interval_controls_enabled():
+                next_interval_index = 1
+                next_interval_dt = tijd[next_interval_index]
+                battery_controls = []
+                for b in range(B):
+                    next_grid_balance = abs(c_l[next_interval_index].x - c_t[next_interval_index].x) <= 0.01
+                    net_power = int(
+                        1000
+                        * (ac_to_dc[b][next_interval_index].x - ac_from_dc[b][next_interval_index].x)
+                    )
+                    minimum_power = int(self.battery_options[b].minimum_power)
+                    operating_mode = self.battery_options[b].entity_set_operating_mode_on
+                    stop_dt = None
+                    soc_at_interval_start = soc[b][next_interval_index].x
+                    if abs(net_power) <= 20:
+                        net_power = 0
+                        operating_mode = self.battery_options[b].entity_set_operating_mode_off
+                    elif not next_grid_balance and minimum_power > 0 and abs(net_power) < minimum_power and self.battery_options[b].entity_stop_inverter is not None and (
+                        len(reduce_power_low_soc[b]) == 0
+                        or soc_at_interval_start > reduce_power_low_soc[b][len(reduce_power_low_soc[b]) - 1]["soc"]
+                    ) and (
+                        len(reduce_power_high_soc[b]) == 0
+                        or soc_at_interval_start < reduce_power_high_soc[b][0]["soc"]
+                    ):
+                        stop_dt = dt.datetime.fromtimestamp(
+                            int(
+                                next_interval_dt.timestamp()
+                                + (abs(net_power) / minimum_power) * self.interval_s
+                            )
+                        )
+                        net_power = minimum_power if net_power > 0 else -minimum_power
+                    elif ac_to_dc[b][next_interval_index].x > 0.0:
+                        net_power = round(
+                            sum(
+                                ac_to_dc_w[b][next_interval_index][cs].x * charge_stages[b][cs]["power"]
+                                for cs in range(CS[b])
+                                if ac_to_dc_w[b][next_interval_index][cs].x > 0
+                            )
+                        )
+                    elif ac_from_dc[b][next_interval_index].x > 0.0:
+                        net_power = -round(
+                            sum(
+                                ac_from_dc_w[b][next_interval_index][ds].x * discharge_stages[b][ds]["power"]
+                                for ds in range(DS[b])
+                                if ac_from_dc_w[b][next_interval_index][ds].x > 0
+                            )
+                        )
+                    battery_controls.append(
+                        {
+                            "index": b,
+                            "net_power": net_power,
+                            "operating_mode": operating_mode,
+                            "stop_datetime": (
+                                stop_dt.strftime("%Y-%m-%d %H:%M")
+                                if stop_dt is not None
+                                else "2000-01-01 00:00:00"
+                            ),
+                        }
+                    )
+
+                ev_controls = []
+                for e in range(EV):
+                    ampere = 0
+                    if ready_u[e] >= next_interval_index:
+                        for cs in range(ECS[e])[1:]:
+                            if stage_factor[e][cs][next_interval_index].x > 0:
+                                ampere = ev_charge_stages[e][cs]["ampere"]
+                                break
+                    ev_controls.append({"index": e, "ampere": ampere})
+
+                self._store_next_interval_controls_cache(
+                    {
+                        "interval_start": next_interval_dt.strftime("%Y-%m-%d %H:%M:%S"),
+                        "battery_controls": battery_controls,
+                        "ev_controls": ev_controls,
+                    }
+                )
+                logging.info(
+                    "Vooraf berekende batterij- en EV-instellingen gecached voor %s",
+                    next_interval_dt.strftime("%Y-%m-%d %H:%M:%S"),
+                )
             #####################################
 
             ###########################################

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -73,6 +73,7 @@ class DaCalc(DaBase):
             )
             return
 
+        applied_battery_controls = []
         for battery_control in cache_data.get("battery_controls", []):
             try:
                 battery_options = self.battery_options[battery_control["index"]]
@@ -92,9 +93,18 @@ class DaCalc(DaBase):
                         entity_id=battery_options.entity_stop_inverter,
                         datetime=battery_control["stop_datetime"],
                     )
+                applied_battery_controls.append(
+                    {
+                        "index": battery_control["index"],
+                        "net_power": battery_control["net_power"],
+                        "operating_mode": battery_control["operating_mode"],
+                        "stop_datetime": battery_control["stop_datetime"],
+                    }
+                )
             except Exception as ex:
                 logging.warning(f"Kon preload voor batterij niet toepassen: {ex}")
 
+        applied_ev_controls = []
         for ev_control in cache_data.get("ev_controls", []):
             try:
                 ev_options = self.ev_options[ev_control["index"]]
@@ -102,6 +112,14 @@ class DaCalc(DaBase):
                     self.get_state(ev_options.entity_plugged_in).state != "on"
                     or self.get_state(ev_options.entity_position).state != "home"
                 ):
+                    applied_ev_controls.append(
+                        {
+                            "index": ev_control["index"],
+                            "ampere": ev_control["ampere"],
+                            "applied": False,
+                            "reason": "not_home_or_unplugged",
+                        }
+                    )
                     continue
                 if float(ev_control["ampere"]) > 0:
                     self.set_value(
@@ -112,10 +130,22 @@ class DaCalc(DaBase):
                 else:
                     self.set_value(ev_options.entity_set_charging_ampere, 0)
                     self.turn_off(ev_options.charge_switch)
+                applied_ev_controls.append(
+                    {
+                        "index": ev_control["index"],
+                        "ampere": ev_control["ampere"],
+                        "applied": True,
+                    }
+                )
             except Exception as ex:
                 logging.warning(f"Kon preload voor EV niet toepassen: {ex}")
 
-        logging.info("Vooraf berekende batterij- en EV-instellingen toegepast voor %s", interval_start_str)
+        logging.info(
+            "Vooraf berekende instellingen toegepast voor %s | batterijen=%s | ev=%s",
+            interval_start_str,
+            json.dumps(applied_battery_controls, ensure_ascii=True),
+            json.dumps(applied_ev_controls, ensure_ascii=True),
+        )
 
     def _get_primary_battery_options(self):
         if self.battery_options is None:
@@ -141,6 +171,7 @@ class DaCalc(DaBase):
     def _store_next_interval_controls_cache(self, cache_payload: dict) -> None:
         cache_file = DaCalc._next_interval_controls_cache_file
         try:
+            cache_file.parent.mkdir(parents=True, exist_ok=True)
             cache_file.write_text(
                 json.dumps(cache_payload, ensure_ascii=True),
                 encoding="utf-8",
@@ -149,6 +180,22 @@ class DaCalc(DaBase):
             logging.warning(
                 f"Kon preload-cache niet opslaan in cachebestand ({cache_file}): {ex}"
             )
+
+    def _format_next_interval_controls_for_log(
+        self, battery_controls: list[dict], ev_controls: list[dict]
+    ) -> tuple[str, str]:
+        battery_parts = []
+        for control in battery_controls:
+            battery_parts.append(
+                f"B{control['index']}: {control['net_power']}W, modus={control['operating_mode']}, stop={control['stop_datetime']}"
+            )
+        ev_parts = []
+        for control in ev_controls:
+            ev_parts.append(f"EV{control['index']}: {control['ampere']}A")
+
+        battery_summary = ", ".join(battery_parts) if battery_parts else "geen"
+        ev_summary = ", ".join(ev_parts) if ev_parts else "geen"
+        return battery_summary, ev_summary
 
     def calc_optimum(
         self,
@@ -3820,16 +3867,28 @@ class DaCalc(DaBase):
                 next_grid_set_point = round(
                     1000 * (c_l[1].x - c_t[1].x) / hour_fraction[1], 0
                 )
+            if U > 1:
+                logging.info(
+                    "Verwachte grid set point volgend interval (%s): %s W",
+                    tijd[1].strftime("%Y-%m-%d %H:%M:%S"),
+                    next_grid_set_point,
+                )
             if not self.debug:
                 # export the ess grid setpoint in W
                 setpoint_entity_id = self._resolve_grid_setpoint_entity_id()
                 if setpoint_entity_id is not None:
+                    logging.info(
+                        "HA write (bron=grid_set_point_huidig): %s W -> %s",
+                        grid_set_point,
+                        setpoint_entity_id,
+                    )
                     self.set_value(setpoint_entity_id, grid_set_point)
                 else:
                     logging.info(
                         "Geen grid setpoint-entity geconfigureerd; setpoint niet naar HA geschreven"
                     )
             if not self.debug and self._preload_next_interval_controls_enabled():
+                next_interval_cache_payload = None
                 next_interval_index = 1
                 next_interval_dt = tijd[next_interval_index]
                 battery_controls = []
@@ -3906,9 +3965,16 @@ class DaCalc(DaBase):
                         "ev_controls": ev_controls,
                     }
                 )
+                next_interval_cache_payload = {
+                    "interval_start": next_interval_dt.strftime("%Y-%m-%d %H:%M:%S"),
+                    "battery_controls": battery_controls,
+                    "ev_controls": ev_controls,
+                }
                 logging.info(
-                    "Vooraf berekende batterij- en EV-instellingen gecached voor %s",
+                    "Vooraf berekende instellingen gecached voor %s | batterijen=%s | ev=%s",
                     next_interval_dt.strftime("%Y-%m-%d %H:%M:%S"),
+                    json.dumps(battery_controls, ensure_ascii=True),
+                    json.dumps(ev_controls, ensure_ascii=True),
                 )
             #####################################
 
@@ -4235,6 +4301,16 @@ class DaCalc(DaBase):
                     if stop_omvormer:
                         logging.info(f"tot: {stop_str}")
                 else:
+                    battery_set_power_entity = self._get_option(
+                        "entity set power feedin", self.battery_options[b]
+                    )
+                    if battery_set_power_entity is not None:
+                        logging.info(
+                            "HA write (bron=battery_dispatch_%s): %s W -> %s",
+                            bat_name,
+                            netto_vermogen_bat,
+                            battery_set_power_entity,
+                        )
                     self.set_entity_value(
                         "entity set power feedin",
                         self.battery_options[b],
@@ -4424,6 +4500,21 @@ class DaCalc(DaBase):
                             f"uur {u:>2} tijdstip {tijd[u].strftime('%H:%M')} "
                             f"consumption: {c_ma_u[m][u].x:>7.3f} tarief: {pl[u]:.4f}"
                         )
+
+            if next_interval_cache_payload is not None:
+                battery_summary, ev_summary = (
+                    self._format_next_interval_controls_for_log(
+                        next_interval_cache_payload["battery_controls"],
+                        next_interval_cache_payload["ev_controls"],
+                    )
+                )
+                logging.info(
+                    "Eindstatus cache volgend %s %s | batterijen: %s | ev: %s",
+                    self.interval_name,
+                    next_interval_cache_payload["interval_start"],
+                    battery_summary,
+                    ev_summary,
+                )
 
         except Exception as ex:
             error_handling(ex)


### PR DESCRIPTION
## Summary
This PR preloads the previously computed grid setpoint into Home Assistant at the start of a new optimization run.

## Why
At quarter/hour boundaries there can be a short gap before a new optimization result is written, which can make the setpoint appear to "drop" or not be visibly applied in time. By restoring the precomputed next setpoint immediately at run start, the controller behavior stays continuous.

## What changed
- Added a small in-memory + file-backed cache for the next grid setpoint.
- Restored cached setpoint to HA at the beginning of `calc_optimum()`.
- Reused existing battery feed-in entity resolution (`entity_set_power_feedin`) to avoid introducing new config fields.
- After each run, cached and persisted the next interval setpoint (`../data/next_grid_set_point_cache.json`).
- Added guarded logging for missing entity/config and cache read/write failures.

## Scope
- Intended as a minimal, targeted change.
- Only updates `dao/prog/day_ahead.py`.

## Validation
- Syntax validated with: `python3 -m py_compile dao/prog/day_ahead.py`
- Deployed and restarted on NixOS using `scripts/sync-to-vm.sh` for runtime testing.

## Notes
- This PR targets the RC branch: `2026.7.0.rc`.
