### PR TITLE
Fix ev charging logic

### DIFF
--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -1859,12 +1859,15 @@ class DaCalc(DaBase):
                         """
                     # som van alle oplaadfactoren is 1
                     model += (xsum(stage_factor[e][cs][u] for cs in range(ECS[e]))) == 1
-                    """
-                    # som van alle schakelaars boven 0 A en kleiner of gelijk aan 1
+
+                    # per interval mag maar een echte laadstap aan staan.
+                    # een lader kan niet tegelijk op 6 A en op 10 A staan.
+                    # stap 0 (0 A) doet hier niet mee: die vangt het deel van
+                    # het interval op waarin niet geladen wordt. zo blijft
+                    # deellading binnen een interval mogelijk.
                     model += (
-                        xsum(stage_on[e][cs][u] for cs in range(ECS[e]))
+                        xsum(stage_on[e][cs][u] for cs in range(ECS[e])[1:])
                     ) <= 1
-                    """
                     model += c_ev[e][u] == xsum(
                         stage_consumption[e][cs][u] for cs in range(ECS[e])
                     )
@@ -1931,6 +1934,17 @@ class DaCalc(DaBase):
                         model += ev_boundary_stop[e][u] >= (
                             ev_is_on[e][u] + ev_is_off[e][u + 1] - 1
                         )
+
+                # zonder stop-entiteit kan de lader niet halverwege een
+                # interval stoppen. interval 0 moet dan helemaal aan of
+                # helemaal uit zijn. alleen interval 0 telt, want alleen dat
+                # interval wordt echt naar de lader gestuurd; de rest van het
+                # plan wordt later opnieuw berekend.
+                can_stop = (not ev_instant_charge[e]) and (
+                    self.ev_options[e].entity_stop_charging is not None
+                )
+                if (not can_stop) and (ready_u[e] > 0):
+                    model += ev_is_partial[e][0] == 0
 
                 model += ev_partial_sum[e] == xsum(
                     ev_is_partial[e][u] for u in range(ready_u[e] + 1)
@@ -3831,20 +3845,41 @@ class DaCalc(DaBase):
                     f"{stage_factor[e][cs][0].x:.2f}" for cs in range(ECS[e])[1:]
                 )
                 logging.debug(line)
-                for cs in range(ECS[e])[1:]:
-                    if stage_factor[e][cs][0].x > 0:
-                        new_ampere_state = ev_charge_stages[e][cs]["ampere"]
-                        if new_ampere_state > 0:
-                            new_switch_state = "on"
-                        if (stage_factor[e][cs][0].x < 1) and (
-                            energy_needed[e] > (ev_accu_in[e][0].x + 0.01)
-                        ):
-                            new_ts = (
-                                start_dt.timestamp() + stage_factor[e][cs][0].x * 3600
-                            )
-                            stop_laden = dt.datetime.fromtimestamp(int(new_ts))
-                            new_state_stop_laden = stop_laden.strftime("%Y-%m-%d %H:%M")
-                        break
+                # na de exclusiviteits-constraint hoort er maar een laadstap
+                # actief te zijn. we nemen de stap met het grootste aandeel,
+                # niet de eerste. hele kleine waarden zijn rekenruis van de
+                # solver en negeren we.
+                stage_tol = 1e-4
+                active_stages = [
+                    cs
+                    for cs in range(ECS[e])[1:]
+                    if stage_factor[e][cs][0].x > stage_tol
+                ]
+                if len(active_stages) > 1:
+                    logging.warning(
+                        f"Meer dan een laadstap actief voor "
+                        f"{self.ev_options[e].name}: {active_stages}. "
+                        f"De stap met het grootste aandeel wordt gebruikt."
+                    )
+                if len(active_stages) > 0:
+                    cs = max(
+                        active_stages, key=lambda k: stage_factor[e][k][0].x
+                    )
+                    stage_fraction = stage_factor[e][cs][0].x
+                    new_ampere_state = ev_charge_stages[e][cs]["ampere"]
+                    if new_ampere_state > 0:
+                        new_switch_state = "on"
+                    if (stage_fraction < 1) and (
+                        energy_needed[e] > (ev_accu_in[e][0].x + 0.01)
+                    ):
+                        # stage_fraction is een deel van dit interval, niet van
+                        # een heel uur. daarom maal hour_fraction[0].
+                        new_ts = (
+                            start_dt.timestamp()
+                            + stage_fraction * hour_fraction[0] * 3600
+                        )
+                        stop_laden = dt.datetime.fromtimestamp(int(new_ts))
+                        new_state_stop_laden = stop_laden.strftime("%Y-%m-%d %H:%M")
                 ev_name = self.ev_options[e].name
                 logging.info(f"Berekeningsuitkomst voor opladen van {ev_name}:")
                 logging.info(

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -1830,20 +1830,63 @@ class DaCalc(DaBase):
             for _ in range(EV)
         ]  # penalty per interval in eur
 
+        ev_energy_slack = 0.001  # kWh
+        # minimale schakelduur voor de laadpaal (seconden). Korter is niet
+        # uitvoerbaar: een relais dat een paar seconden dichtvalt levert niets
+        # nuttigs op, en de stoptijd wordt afgerond op hele minuten.
+        ev_min_duty_s = 300.0
+
         for e in range(EV):
             if (energy_needed[e] > 0) and (ready_u[e] < U):
+                # kleinste hoeveelheid energie die met deze minimumduur nog
+                # geleverd kan worden (kWh). Is er minder nodig, dan zou de eis
+                # het model onoplosbaar maken en slaan we hem over.
+                min_stage_accu = min(
+                    ev_charge_stages[e][cs]["accu_power"]
+                    for cs in range(1, ECS[e])
+                    if ev_charge_stages[e][cs]["accu_power"] > 0
+                )
+                min_deliverable = min_stage_accu * ev_min_duty_s / 3600
+                apply_min_duty = energy_needed[e] >= min_deliverable + ev_energy_slack
+                if not apply_min_duty:
+                    logging.info(
+                        f"EV {self.ev_options[e].name}: minimale schakelduur van "
+                        f"{ev_min_duty_s:.0f} s wordt niet toegepast; er is maar "
+                        f"{energy_needed[e]:.3f} kWh nodig en de kortste "
+                        f"schakelactie levert al {min_deliverable:.3f} kWh."
+                    )
+
                 for u in range(ready_u[e] + 1):
                     # laden, alles uitgedrukt in vermogen kW
+                    # uur-fractie van dit interval: het laatste interval loopt
+                    # maar tot de deadline, de rest is een heel interval
+                    if u == ready_u[e]:
+                        hr_fraction = (ev_ready_dt[e] - tijd[u]).total_seconds() / 3600
+                    else:
+                        hr_fraction = hour_fraction[u]
+
+                    # stage_factor is een fractie van hr_fraction, niet van een
+                    # heel uur. De minimale duty verschilt dus per interval. Is
+                    # het interval zelf korter dan de minimumduur, dan wordt
+                    # min_duty 1: helemaal aan of helemaal uit.
+                    if apply_min_duty and hr_fraction > 0:
+                        min_duty = min(1.0, ev_min_duty_s / (hr_fraction * 3600))
+                    else:
+                        min_duty = 0.0
+
                     for cs in range(ECS[e]):
                         model += stage_on[e][cs][u] - stage_factor[e][cs][u] <= 0.9999
                         model += stage_on[e][cs][u] - stage_factor[e][cs][u] >= 0
+                        # een echte stap staat uit, of draait minstens
+                        # ev_min_duty_s seconden
+                        if cs >= 1 and min_duty > 0:
+                            model += (
+                                stage_factor[e][cs][u] >= min_duty * stage_on[e][cs][u]
+                            )
+
                     for cs in range(ECS[e]):
                         # daadwerkelijk ac verbruik (kWh) per stage =
                         # vermogen van de stap x oplaadfactor (0..1) x uur-fractie
-                        if u == ready_u[e]:
-                            hr_fraction = (ev_ready_dt[e] - tijd[u]).total_seconds() / 3600
-                        else:
-                            hr_fraction = hour_fraction[u]
                         model += (
                             stage_consumption[e][cs][u]
                             == ev_charge_stages[e][cs]["power"]
@@ -1969,7 +2012,6 @@ class DaCalc(DaBase):
                 # above) can turn a trivially-achievable target into a hard
                 # infeasibility from float noise alone. 1 Wh (0.001 kWh) is
                 # far below anything physically meaningful here.
-                ev_energy_slack = 0.001  # kWh
                 model += (
                     xsum(ev_accu_in[e][u] for u in range(ready_u[e] + 1))
                     <= energy_needed[e] + ev_energy_slack


### PR DESCRIPTION
OK, i went down the rabbit hole for asking AI to make me a testplan that would cover all different branches of the EV charging logic.
It was more work then expected, but i like the end result.

# EV charging test report — 2026-07-25 14:02:34

**23 passed, 0 failed, 0 setup mismatch, 0 error, 0 infeasible** out of 23 cases.

| ID | Status | Description | Scheduled | Energy needed (kWh) | Partial/Boundary/Start-stops | Min factor | Solve (s / nodes / gap) |
|---|---|---|---|---|---|---|---|
| 1.1 | PASS | Golf blend trap: 30->63%, ready +4h, ~3.00 kW avg | True | 11.979 | 1/1/2 | 0.7235 | 4.01 / 98 / 0.016244088 |
| 1.2 | PASS | Golf near 16A ceiling: 30->67%, ready +4h | True | 13.431 | 1/0/0 | 0.8657 | 2.54 / 64 / 0.0043362518 |
| 1.3 | PASS | Golf below 10A capacity: 30->63%, ready +8h | True | 11.979 | 1/1/2 | 0.7062 | 10.97 / 628 / 0.012772862 |
| 1.4 | PASS | Golf small job, lots of slack: 30->40%, ready +2h | True | 3.630 | 3/0/4 | 0.3333 | 2.72 / 81 / 0.0041389829 |
| 1.5 | PASS | Golf above max power: 30->63%, ready +3h20m -> auto-adjusted | True | 11.239 | 2/1/4 | 0.9989 | 2.45 / 65 / 0.0041392963 |
| 2.1 | PASS | Already at target level | False | 0.000 | 0/0/0 | — | 2.11 / 64 / 0.0046112232 |
| 2.2 | PASS | Car away | False | 11.979 | 0/0/0 | — | 2.11 / 73 / 0.0042731573 |
| 2.3 | PASS | Not plugged in | False | 11.979 | 0/0/0 | — | 2.09 / 70 / 0.0040228024 |
| 2.4 | PASS | Ready time in the past | False | 0.000 | 0/0/0 | — | 2.24 / 78 / 0.0046112232 |
| 2.5 | PASS | Ready beyond horizon | False | 11.979 | 0/0/0 | — | 3.35 / 66 / 0.0046112232 |
| 2.6 | PASS | Combine away + unplugged + stale ready | False | 11.979 | 0/0/0 | — | 1.99 / 72 / 0.0040228024 |
| 4.3 | PASS | Ready near end of current interval -> ready_u == 0 | True | 0.804 | 1/0/0 | 0.9988 | 2.14 / 73 / 0.0039824845 |
| 4.4 | PASS | No stop entity, blend-trap case -> interval 0 must be 0/1 | True | 11.979 | 1/0/0 | 0.7785 | 4.98 / 154 / 0.0069746202 |
| 5.1 | PASS | Instant charge on, Golf 30% | True | 25.410 | 2/1/4 | 0.3333 | 1.73 / 34 / 0.00400736 |
| 1.6 | PASS | Zero-slack energy_needed infeasibility regression: Golf 30%, ready +1h50m (clamped to max_possible, per fix prompt's exact repro) | True | 6.069 | 1/1/2 | 0.9988 | 2.43 / 69 / 0.0043362518 |
| 3.3 | PASS | Day rollover: short HH:MM:SS ready time, earlier than start -> next day | True | 5.925 | 1/1/2 | 0.9988 | 1.77 / 83 / 0.0049188905 |
| 6.7 | PASS | Two EVs simultaneously: Golf 30->63% + Tesla 35->80%, both ready +4h | True | 11.979 | 1/0/0 | 0.8459 | 8.46 / 605 / 0.0078324393 |
| 1.T | PASS | Tesla control: monotone curve, should single-stage trivially | True | 24.750 | 3/0/4 | 0.3333 | 3.87 / 95 / 0.0042132348 |
| 7.1 | PASS | Golf duty sliver, slack window: 6 full intervals + 0.22 kWh, ready +6h | True | 5.298 | 2/0/2 | 0.3333 | 2.56 / 61 / 0.0043362518 |
| 7.2 | PASS | Golf duty sliver, near-saturated window: 10 full intervals + 0.24 kWh, ready +3h | True | 8.704 | 1/0/0 | 0.9411 | 4.5 / 116 / 0.0061897565 |
| 7.3 | PASS | Tesla duty sliver (monotone curve control): 6 full intervals + 0.02 kWh, ready +5h | True | 15.918 | 5/0/8 | 0.3333 | 4.36 / 98 / 0.012010624 |
| 7.4 | PASS | Golf duty sliver with no stop entity: 4 full intervals + 0.20 kWh, ready +4h | True | 3.586 | 2/1/4 | 0.4556 | 2.28 / 47 / 0.0047482612 |
| 7.5 | PASS | Tesla small top-up near the min-duty feasibility guard: 60->61.2% | True | 0.660 | 1/0/0 | 0.4108 | 7.43 / 468 / 0.015412118 |