### PR TITLE
added calc_optimum_met_debug as valid option.

### DIFF
--- a/dao/prog/config/models/scheduler.py
+++ b/dao/prog/config/models/scheduler.py
@@ -12,6 +12,7 @@ SchedulerAction = Literal[
     "get_tibber_data",
     "get_day_ahead_prices",
     "calc_optimum",
+    "calc_optimum_met_debug",
     "clean_data",
     "calc_baseloads",
     "train_ml_predictions",


### PR DESCRIPTION
My test setup runs in schadow with the calc_optimum_met_debug. But this wasn't accepted by the verifier. This fix makes it a valid option.

Final try.