### PR TITLE
Add two additive hooks to enable debugging of the solver.

### DIFF
--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -3255,7 +3255,16 @@ class DaCalc(DaBase):
         # model.max_seconds = 20
         if self.log_level > logging.DEBUG:
             model.verbose = 1
-        model.threads = -1 #use all available cores
+        model.threads = getattr(self, "_solver_threads", -1)
+        if getattr(self, "_debug_capture_vars", False):
+            try:
+                from da_debug import build_var_registry
+
+                self._debug_vars = build_var_registry(locals())
+            except Exception:
+                logging.warning(
+                    "Kon debug variabele-registry niet opbouwen", exc_info=True
+                )
         # model.check_optimization_results()
 
         # kosten optimalisering


### PR DESCRIPTION
Remember the automated testcases for the EV section?

I'm working on a framework to extend the testing for the whole file. With also the goal to run this in automated CI of github.
Therefore the solver must be able to run scenarios without the HA or database backend. Therefore the following four capabilities are planned:

### 1. Snapshot capture
A flag on a normal optimisation run. When set, the run writes one file containing every input it read: day-ahead prices, the solar and consumption prognosis, every Home Assistant entity value it consulted, the calculated  baseload, heat-pump run hours, the asset configuration, and the time.
### 2. Replay 
Point a command at a snapshot and the identical optimisation runs again: same prices, same SoC, same entity states, same clock, single-threaded, with no HA and no DB connection. It runs on your laptop, in a container, or on a GitHub runner, and writes nothing back to HA.
### 3.  Interval dump
Given a solved model and an interval, print everything the solver knew about that interval: every variable with a readable name and its value, which constraints are actually binding, which SOS2 stage is active on each piecewise curve and whether the active weights are adjacent, plus reduced context for the neighbouring intervals. 
This might also help users with questions like: My battery does this, but i expected that. Now the solver can maybe shine a light on that specific interval why things were what they were.
### 4. Scenario suite
A declarative test case is a snapshot plus a delta: override some entity values, transform the price curve, patch a config field, then assert. This can run on GitHub Actions on every push and every release tag, with no home infrastructure. All the above is necessary to be able to do this.

----

All the above will be in da_debug.py, a separate new file. But da_debug needs two hooks towards day_ahead.py to intercept the information. 

I make this an independent branch and PR, the changes do not change normal operation, but i need them for further development. In case the above described work turns out too ambitious only reverting this commit from day_ahead.py and everything is back to normal. 