### PR TITLE
Add debug snapshot capture and replay tooling (da_debug.py)

### DIFF
--- a/dao/prog/da_debug.py
+++ b/dao/prog/da_debug.py
@@ -1,15 +1,14 @@
 """
 Snapshot capture and hermetic replay for ``DaCalc.calc_optimum()``.
 
-See ``dao_debug_replay_ci_architecture_v2.md`` sections 2.1 and 2.2 for the
-design this implements. In short: ``calc_optimum()`` crosses several
-external-state boundaries (database, Home Assistant REST, the wall clock,
-the on-disk config) before and during a solve. This module patches those
-boundaries at the class/module level — never touching ``day_ahead.py``
-itself beyond the two additive hooks already landed there — so that a run
-can either be recorded to a fixture file (``RecordingIO``) or replayed
-hermetically from one (``ReplayIO``), with no live Home Assistant and no
-database connection required for the latter.
+``calc_optimum()`` crosses several external-state boundaries (database, Home
+Assistant REST, the wall clock, the on-disk config) before and during a
+solve. This module patches those boundaries at the class/module level —
+never touching ``day_ahead.py`` itself beyond two small additive hooks
+(the ``model.threads``/``_debug_capture_vars`` lines near the end of
+``calc_optimum()``) — so that a run can either be recorded to a fixture file
+(``RecordingIO``) or replayed hermetically from one (``ReplayIO``), with no
+live Home Assistant and no database connection required for the latter.
 
 Usage::
 
@@ -27,12 +26,17 @@ Both classes are context managers that must be entered *before* any
 of the channels they patch (config, strategy resolution, the HA REST call in
 the constructor) are read inside ``DaBase.__init__`` itself.
 
-The input cut-set (§2.1), the snapshot format (§2.2), the variable registry
-(§2.3) and ``dump_interval`` (§2.5) are all implemented here. ``RecordingIO``
-and ``ReplayIO`` do not depend on the registry or ``dump_interval`` — those
-are only wired together by the ``dump`` CLI command, which replays a
-snapshot to get a solved model plus its registry and then prints what the
-solver knew about one interval.
+Also included: a variable registry that maps each solver variable back to
+its Python name and index (mip never names variables itself), a
+``dump_interval`` function that renders everything a solved model knew
+about one interval, and a CLI (``python -m dao.prog.da_debug <command>``)
+tying it together — ``capture``/``replay`` for the snapshot lifecycle,
+``dump`` for interval inspection, ``dangling`` for finding unconstrained
+integer/binary columns, plus ``inspect``/``verify``/``diff``/``set``/
+``selftest`` as smaller utilities. ``RecordingIO``/``ReplayIO`` do not
+depend on the registry or ``dump_interval`` themselves — those are only
+wired together by the ``dump`` and ``dangling`` commands, which replay a
+snapshot to get a solved model plus its registry.
 """
 
 from __future__ import annotations
@@ -43,6 +47,7 @@ import hashlib
 import io
 import json
 import logging
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -70,7 +75,7 @@ class SnapshotMiss(RuntimeError):
 
 
 # ---------------------------------------------------------------------------
-# Config sanitisation / reconstruction (A0 Q9 / §2.2)
+# Config sanitisation / reconstruction
 # ---------------------------------------------------------------------------
 
 
@@ -145,7 +150,7 @@ def _config_hash(sanitized: dict) -> str:
 # Weigert de snapshot te schrijven als een echte geheime waarde uit secrets.json 
 # letterlijk in de inhoud voorkomt; vangt lekken die de typecontrole mist.
 def _assert_no_secret_leak(blob: str, secret_values: list[str]) -> None:
-    """Defence in depth alongside type-based exclusion (§2.2): a raw key
+    """Defence in depth alongside type-based exclusion above: a raw key
     pasted into options.json instead of a ``!secret`` reference never
     becomes a ``SecretStr`` the sanitiser can catch by type, but it *is* a
     value that also lives in secrets.json — this catches that case."""
@@ -162,7 +167,7 @@ def _assert_no_secret_leak(blob: str, secret_values: list[str]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# DataFrame <-> JSON payload (§2.2)
+# DataFrame <-> JSON payload
 # ---------------------------------------------------------------------------
 
 
@@ -260,8 +265,9 @@ class _FakeDbManager:
     ``make_db_ha`` normally return. Serves the one channel calc_optimum()
     calls directly (``get_prognose_data``); everything else raises loudly
     rather than silently returning something DB-shaped, since a call
-    reaching here that isn't one of the two known methods means the input
-    cut-set (§1) is incomplete and a new channel needs a real patch."""
+    reaching here that isn't one of the two known methods means
+    ``calc_optimum()`` reads from the database somewhere this module
+    doesn't patch yet, and needs a real patch added."""
 
     # Onthoudt de opgeslagen prognosedata en een label voor duidelijke foutmeldingen.
     def __init__(self, prog_data: Optional[pd.DataFrame], label: str):
@@ -286,8 +292,8 @@ class _FakeDbManager:
         raise SnapshotMiss(
             f"ReplayIO ({self._label}): db_da/db_ha.{name}() was called, but "
             f"ReplayIO only serves get_prognose_data()/log_pool_status(). "
-            f"This means a channel outside the documented input cut-set "
-            f"(architecture doc §1) was reached during replay."
+            f"This means calc_optimum() reached a database channel this "
+            f"module doesn't patch yet."
         )
 
 
@@ -346,7 +352,7 @@ def _import_targets():
     (bare) instead of ``dao.prog.da_report`` would create a *second* module
     object under a different ``sys.modules`` key, with its own distinct
     ``Report`` class — patching that copy would silently do nothing to the
-    class day_ahead.py actually constructs (A0 Q2)."""
+    class day_ahead.py actually constructs."""
     from dao.prog.da_base import DaBase
     from dao.prog.da_report import Report
     from dao.lib.db_manager import DBmanagerObj
@@ -358,9 +364,10 @@ def _import_targets():
 
 # ---------------------------------------------------------------------------
 # Write-primitive no-ops, shared by ReplayIO (always) and RecordingIO's
-# opt-in debug mode (§ "capture --debug"). Suppressing at these primitives
-# rather than chasing call sites is the same principle used for every read
-# channel above: the boundary is the stable thing, the call sites are not.
+# opt-in debug mode (its ``debug=True`` constructor argument). Suppressing
+# at these primitives rather than chasing call sites is the same principle
+# used for every read channel above: the boundary is the stable thing, the
+# call sites are not.
 # ---------------------------------------------------------------------------
 
 
@@ -467,10 +474,10 @@ def _build_result_dict(model, cbc_log_chunks: list[str], extra_meta: dict) -> Op
             "note": (
                 "Per-interval dispatch and SoC trajectory are not captured "
                 "in this result file — objective/status/gap only. Use the "
-                "`dump` CLI command (architecture doc §2.5) against the "
-                "snapshot to see what a solved model knew about a specific "
-                "interval; that needs a live re-solve via ReplayIO and "
-                "isn't something a static result file can hold."
+                "`dump` CLI command against the snapshot to see what a "
+                "solved model knew about a specific interval; that needs a "
+                "live re-solve via ReplayIO and isn't something a static "
+                "result file can hold."
             ),
         }
     except Exception:
@@ -495,8 +502,8 @@ class RecordingIO:
     before solving, which gates most writes) plus, on top of that, the
     same write-primitive no-ops ``ReplayIO`` always applies — because
     `self.debug` alone does *not* gate everything: `self.notify(...)` and
-    one `set_value(entity_avg_temp, ...)` call are unconditional regardless
-    of the flag (architecture doc §1.2). Reads still happen for real and
+    one `set_value(entity_avg_temp, ...)` call in day_ahead.py are
+    unconditional regardless of the flag. Reads still happen for real and
     are still captured; only the write side is suppressed.
 
     ``png`` is a separate switch, independent of ``debug``: day_ahead.py
@@ -652,7 +659,7 @@ class RecordingIO:
 
         self._patches.set(DBmanagerObj, "get_prognose_data", _wrapped_get_prognose_data)
 
-        # Not in the original input cut-set (architecture doc §1): found by
+        # A channel this module doesn't patch anywhere else: found by
         # actually running a real config with a solar device configured for
         # ML prediction. calc_optimum() -> DaBase.calc_solar_predictions()
         # -> SolarPredictor.predict_solar_device() does its own DB reads
@@ -934,8 +941,8 @@ class ReplayIO:
     # Geeft de entity's terug die tijdens de replay daadwerkelijk zijn opgevraagd, om een ongebruikte override op te kunnen sporen.
     def reads(self) -> set[str]:
         """Entity ids actually read via ``get_state`` during the replayed
-        run — lets a caller detect a scenario override nothing consulted
-        (architecture doc §8.3)."""
+        run — lets a caller detect a scenario override that nothing
+        actually consulted (e.g. an entity_id typo in a test fixture)."""
         return set(self._reads)
 
     @property
@@ -1163,143 +1170,213 @@ class ReplayIO:
 
 
 # ---------------------------------------------------------------------------
-# Variable registry (A1's hook 1, §2.3) and dump_interval (A3, §2.5)
+# Variable registry and dump_interval
 # ---------------------------------------------------------------------------
 #
 # day_ahead.py's calc_optimum() already calls build_var_registry(locals())
-# just before model.optimize() when self._debug_capture_vars is set (the
-# hook A1 landed). Nothing here is reachable from an ordinary run: the flag
-# defaults to unset, and everything below is only ever driven by the `dump`
-# CLI command or by tests that build a synthetic mip.Model directly.
+# just before model.optimize() when self._debug_capture_vars is set (a
+# small additive hook near the end of calc_optimum(), guarded by that flag).
+# Nothing here is reachable from an ordinary run: the flag defaults to
+# unset, and everything below is only ever driven by the `dump` CLI command
+# or by tests that build a synthetic mip.Model directly.
 
 
 class VarRegistryError(RuntimeError):
-    """Raised when the registry contains a container with no SHAPES entry
-    and no SHAPES_IGNORE entry — i.e. calc_optimum() grew a new variable
-    family that dump_interval was never taught the axis layout of. This is
-    meant to fail loudly (§2.5's "completeness assertion") rather than
-    silently omit the new container from every future dump."""
+    """Raised when the registry contains a container with no SHAPES entry,
+    or a SHAPES entry with no unit, and no SHAPES_IGNORE entry either —
+    i.e. calc_optimum() grew a new variable family, or an existing SHAPES
+    entry is incomplete, that dump_interval was never taught how to
+    render. Meant to fail loudly rather than silently omit or mis-render
+    part of the model."""
+
+
+class VarRegistry:
+    """Return type of build_var_registry(): the var-idx -> (container,
+    index-path) mapping (dict-like — every call site that already treats
+    the registry as a plain dict keeps working via .items()/.values()/
+    .get()), plus the SOS2 breakpoint sample tables dump_interval
+    annotates weight indices with. The samples are plain float lists —
+    invisible to the usual Var-only walk — so they're pulled out by name
+    instead and carried alongside rather than merged into by_idx."""
+
+    def __init__(self, by_idx: dict, samples: dict):
+        self.by_idx = by_idx
+        self.samples = samples
+
+    def items(self):
+        return self.by_idx.items()
+
+    def values(self):
+        return self.by_idx.values()
+
+    def get(self, key, default=None):
+        return self.by_idx.get(key, default)
+
+    def __len__(self):
+        return len(self.by_idx)
+
+    def __bool__(self):
+        return bool(self.by_idx)
+
+    def __contains__(self, key):
+        return key in self.by_idx
+
+
+# calc_optimum() local names holding the SOS2 breakpoint sample tables —
+# plain nested float lists, not Vars, so the usual walk never sees them;
+# pulled out by name instead.
+_SAMPLE_LOCALS = (
+    "ac_to_dc_samples",
+    "dc_from_ac_samples",
+    "ac_from_dc_samples",
+    "dc_to_ac_samples",
+)
 
 
 # Bouwt {var.idx: (containernaam, indextuple)} uit calc_optimum()'s eigen
 # locals() vlak vóór model.optimize(); loopt alleen door lists/tuples, dus
-# DataFrames, configobjecten en losse scalars worden vanzelf overgeslagen.
-def build_var_registry(local_vars: dict) -> dict[int, tuple[str, tuple]]:
-    """§2.3: ``{var.idx: (container_name, index_tuple)}`` built from
-    ``calc_optimum()``'s own ``locals()`` just before ``model.optimize()``.
+# DataFrames, configobjecten en losse scalars worden vanzelf overgeslagen —
+# behalve een kale Var zelf, die apart wordt opgepikt.
+def build_var_registry(local_vars: dict) -> VarRegistry:
+    """Builds the var-idx -> (container_name, index_tuple) mapping from
+    ``calc_optimum()``'s own ``locals()`` just before ``model.optimize()``,
+    plus the SOS2 breakpoint sample tables.
 
-    Only walks values that are themselves ``list``/``tuple`` at the top
-    level, then recurses through nested lists/tuples looking for ``mip.Var``
-    leaves. This is deliberate, not incidental: mip never names variables
-    (0 of 81 ``add_var`` call sites in day_ahead.py pass ``name=``, per the
-    architecture doc's §0.7 finding 1), so there is nothing to key on but
-    the Python container structure — and restricting the walk to
-    list/tuple means DataFrames, pydantic config objects, and plain scalar
-    locals are dead ends rather than needing an exclude list. Keyed by
-    ``var.idx`` rather than the ``Var`` object itself, because
-    ``mip.Var.__eq__`` returns a ``LinExpr`` rather than a bool and
-    ``var.idx`` is unique per model regardless (architecture doc §2.3).
+    Walks list/tuple values recursively for ``mip.Var`` leaves — mip never
+    names variables (0 of 81 ``add_var`` call sites in day_ahead.py pass
+    ``name=``), so there is nothing to key on but the Python container
+    structure, and restricting the walk to list/tuple means DataFrames,
+    pydantic config objects, and plain scalar locals are dead ends rather
+    than needing an exclude list. Keyed by ``var.idx`` rather than the
+    ``Var`` object itself, because ``mip.Var.__eq__`` returns a ``LinExpr``
+    rather than a bool and ``var.idx`` is unique per model regardless.
+
+    A *bare* ``mip.Var`` directly in ``locals()`` (``cost``, ``delivery``,
+    ``production``) is registered too, under its own name with an empty
+    index path — without this, these fall through to ``var(idx)``
+    everywhere they appear, including the objective row.
     """
-    registry: dict[int, tuple[str, tuple]] = {}
+    by_idx: dict[int, tuple[str, tuple]] = {}
+    samples: dict[str, list] = {}
     if mip is None:
-        return registry
+        return VarRegistry(by_idx, samples)
 
     # Loopt recursief door een (geneste) list/tuple en registreert elke
     # Var-leaf onder zijn containernaam en indexpad.
     def _walk(name: str, value, path: tuple) -> None:
         if isinstance(value, mip.Var):
-            registry[value.idx] = (name, path)
+            by_idx[value.idx] = (name, path)
         elif isinstance(value, (list, tuple)):
             for i, item in enumerate(value):
                 _walk(name, item, path + (i,))
-        # Everything else (DataFrame, dict, pydantic model, float, str,
-        # None, ...) is neither a Var nor a container to recurse into.
 
     for name, value in local_vars.items():
-        if isinstance(value, (list, tuple)):
+        if name in _SAMPLE_LOCALS and isinstance(value, list):
+            samples[name] = value
+            continue
+        if isinstance(value, mip.Var):
+            by_idx[value.idx] = (name, ())
+        elif isinstance(value, (list, tuple)):
             _walk(name, value, ())
-    return registry
+
+    return VarRegistry(by_idx, samples)
 
 
-# Declaratieve as-indeling per containernaam: welke Python-loopvariabele
-# hoort bij welke positie in de geneste lijst. "u" is het interval-as,
-# "u_boundary" is dezelfde as maar met lengte U+1 (SoC-grenzen). Geschreven
-# tegen de huidige day_ahead.py door de model-bouwsectie te lezen, niet
-# afgeleid uit de namen — zie de architectuurdoc §2.5 voor het voorbeeld dat
-# dit uitbreidt.
-SHAPES: dict[str, tuple[str, ...]] = {
+# Declaratieve as-indeling, eenheid en korte omschrijving per containernaam.
+# "u" is de interval-as, "u_boundary" is dezelfde as maar met lengte U+1
+# (grenswaarden zoals SoC). Geschreven tegen de huidige day_ahead.py door de
+# model-bouwsectie te lezen en tegen een echte config-run (2 EV's,
+# 1 batterij) te toetsen, niet afgeleid uit namen alleen.
+#
+# Drie eenheden die op het eerste gezicht anders lijken dan hun naam
+# suggereert, opgehelderd door de daadwerkelijke berekening in
+# day_ahead.py te volgen:
+#   - c_ma_kw is kWh, niet kW: het wordt gevuld via `power[...] / 4000`
+#     (W -> kWh per kwartier van 15 min), ondanks de "_kw" in de naam (dat
+#     staat voor "kwartier", niet "kilowatt").
+#   - low_soc_penalty_int is €, niet een vlag: continue kostenbijdrage per
+#     interval (`low_soc_penalty[e] == Σ low_soc_penalty_int[e][u]`).
+#   - p_hp is W, niet kW: de bound is `hp_stages[s]["max_power"]`
+#     ongedeeld, en de latere omzetting naar kWh deelt expliciet door 1000
+#     (`c_hp[u] == Σp_hp[s][u] * hour_fraction[u] / 1000`) — dat delen door
+#     1000 is alleen zinnig als p_hp zelf in W staat.
+SHAPES: dict[str, tuple[tuple[str, ...], str, str]] = {
     # solar (top-level AC-coupled arrays, independent of any battery)
-    "pv_ac": ("s", "u"),
-    "pv_ac_on_off": ("s", "u"),
+    "pv_ac": (("s", "u"), "kW", "AC-coupled solar production"),
+    "pv_ac_on_off": (("s", "u"), "bool", "AC-coupled solar inverter on/off"),
     # battery — DC-coupled solar feeding this battery specifically
-    "pv_dc_on_off": ("b", "pvdc", "u"),
-    "pv_prod_dc_sum": ("b", "u"),
-    # battery — AC<->DC, both curves are SOS2 (§2.5); the commented
+    "pv_dc_on_off": (("b", "pvdc", "u"), "bool", "DC-coupled solar switch"),
+    "pv_prod_dc_sum": (("b", "u"), "kW", "DC-coupled solar production, summed"),
+    # battery — AC<->DC, both curves are SOS2; the commented
     # on/off-without-SOS alternatives never execute, so they never appear
     # in locals() and need no entry here
-    "ac_to_dc": ("b", "u"),
-    "ac_to_dc_on": ("b", "u"),
-    "ac_to_dc_w": ("b", "u", "cs"),  # SOS2 weight, charge
-    "ac_from_dc": ("b", "u"),
-    "ac_from_dc_on": ("b", "u"),
-    "ac_from_dc_w": ("b", "u", "ds"),  # SOS2 weight, discharge
-    "dc_from_ac": ("b", "u"),
-    "dc_to_ac": ("b", "u"),
-    "dc_from_bat": ("b", "u"),
-    "dc_to_bat": ("b", "u"),
-    "soc": ("b", "u_boundary"),
-    "soc_low": ("b", "u_boundary"),
-    "soc_mid": ("b", "u_boundary"),
-    "cycle_cost": ("b",),
-    "penalty_cost": ("b",),
+    "ac_to_dc": (("b", "u"), "kW", "battery charge power, AC side"),
+    "ac_to_dc_on": (("b", "u"), "bool", "battery charging this interval"),
+    "ac_to_dc_w": (("b", "u", "cs"), "0..1", "SOS2 weight, charge"),
+    "ac_from_dc": (("b", "u"), "kW", "battery discharge power, AC side"),
+    "ac_from_dc_on": (("b", "u"), "bool", "battery discharging this interval"),
+    "ac_from_dc_w": (("b", "u", "ds"), "0..1", "SOS2 weight, discharge"),
+    "dc_from_ac": (("b", "u"), "kW", "battery charge power, DC side"),
+    "dc_to_ac": (("b", "u"), "kW", "battery discharge power, DC side"),
+    "dc_from_bat": (("b", "u"), "kW", "power out of the battery cells"),
+    "dc_to_bat": (("b", "u"), "kW", "power into the battery cells"),
+    "soc": (("b", "u_boundary"), "%", "state of charge"),
+    "soc_low": (("b", "u_boundary"), "%", "SoC share below the optimal-low split"),
+    "soc_mid": (("b", "u_boundary"), "%", "SoC share above the optimal-low split"),
+    "cycle_cost": (("b",), "€", "accumulated battery cycling cost"),
+    "penalty_cost": (("b",), "€", "accumulated low-SoC penalty"),
     # boiler (single, not indexed by asset)
-    "boiler_on": ("u",),
-    "boiler_st": ("u",),
-    "boiler_temp": ("u_boundary",),
-    "c_b": ("u",),
+    "boiler_on": (("u",), "bool", "boiler heating this interval"),
+    "boiler_st": (("u",), "bool", "boiler heating starts this interval"),
+    "boiler_temp": (("u_boundary",), "°C", "boiler temperature"),
+    "c_b": (("u",), "kWh", "boiler consumption"),
     # ev — note stage_* is [e][ecs][u] (stage before interval), while every
     # other per-ev container is [e][u]; a transposed index here would
-    # produce plausible-looking wrong numbers (architecture doc §8.5)
-    "stage_consumption": ("e", "ecs", "u"),
-    "stage_factor": ("e", "ecs", "u"),
-    "stage_on": ("e", "ecs", "u"),
-    "c_ev": ("e", "u"),
-    "p_ev": ("e", "u"),
-    "ev_accu_in": ("e", "u"),
-    "ev_soc_kwh": ("e", "u"),
-    "ev_is_on": ("e", "u"),
-    "ev_is_off": ("e", "u"),
-    "ev_is_partial": ("e", "u"),
-    "ev_boundary_stop": ("e", "u"),
-    "ev_partial_sum": ("e",),
-    "ev_boundary_sum": ("e",),
-    "ev_start_stops_sum": ("e",),
-    "ev_delta_soc": ("e", "u"),
-    "low_soc_penalty_int": ("e", "u"),
-    "low_soc_penalty": ("e",),
-    "switch_cost": ("e",),
+    # produce plausible-looking wrong numbers
+    "stage_consumption": (("e", "ecs", "u"), "kWh", "EV charge-stage consumption"),
+    "stage_factor": (("e", "ecs", "u"), "0..1", "EV charge-stage weight"),
+    "stage_on": (("e", "ecs", "u"), "bool", "EV charge-stage active"),
+    "c_ev": (("e", "u"), "kWh", "EV charger consumption"),
+    "p_ev": (("e", "u"), "kW", "EV charger power"),
+    "ev_accu_in": (("e", "u"), "kWh", "energy into the EV battery"),
+    "ev_soc_kwh": (("e", "u"), "kWh", "EV state of charge"),
+    "ev_is_on": (("e", "u"), "bool", "EV charging this interval"),
+    "ev_is_off": (("e", "u"), "bool", "EV not charging this interval"),
+    "ev_is_partial": (("e", "u"), "bool", "EV charging below full stage power"),
+    "ev_boundary_stop": (("e", "u"), "bool", "EV stop lands on an interval boundary"),
+    "ev_partial_sum": (("e",), "count", "count of partial-power intervals"),
+    "ev_boundary_sum": (("e",), "count", "count of boundary-stop intervals"),
+    "ev_start_stops_sum": (("e",), "count", "count of charger start/stops"),
+    "ev_delta_soc": (("e", "u"), "%", "EV SoC shortfall vs. wished level"),
+    "low_soc_penalty_int": (("e", "u"), "€", "EV low-SoC penalty, per interval"),
+    "low_soc_penalty": (("e",), "€", "accumulated EV low-SoC penalty"),
+    "switch_cost": (("e",), "€", "accumulated EV charger switch cost"),
     # grid
-    "c_l": ("u",),
-    "c_t": ("u",),
-    "c_l_on": ("u",),
-    "c_t_on": ("u",),
+    "c_l": (("u",), "kWh", "grid import"),
+    "c_t": (("u",), "kWh", "grid export"),
+    "c_l_on": (("u",), "bool", "importing this interval"),
+    "c_t_on": (("u",), "bool", "exporting this interval"),
     # heat pump — mutually exclusive per run depending on
     # heating_options.adjustment: "on/off" builds hp_bl_on/hp_start_index,
-    # "power"/"heating curve" builds p_hp/hp_s_w (third active add_sos() —
-    # architecture doc §11, A0 Q7). Note p_hp is [s][u] while its own
-    # SOS2 weight hp_s_w is [u][s] — transposed relative to each other,
-    # same class of trap as the EV stage arrays above.
-    "c_hp": ("u",),
-    "hp_on": ("u",),
-    "h_hp": ("u",),
-    "hp_bl_on": ("blk", "u"),
-    "hp_start_index": ("blk",),
-    "p_hp": ("s_hp", "u"),
-    "hp_s_w": ("u", "s_hp"),  # SOS2 weight, heat pump
+    # "power"/"heating curve" builds p_hp/hp_s_w (a third active add_sos()
+    # site, alongside the two battery curves). Note p_hp is [s][u] while
+    # its own SOS2 weight hp_s_w is [u][s] — transposed relative to each
+    # other, same class of trap as the EV stage arrays above.
+    "c_hp": (("u",), "kWh", "heat pump consumption"),
+    "hp_on": (("u",), "bool", "heat pump running this interval"),
+    "h_hp": (("u",), "kWh", "heat produced"),
+    "hp_bl_on": (("blk", "u"), "bool", "heat pump on/off block active"),
+    "hp_start_index": (("blk",), "idx", "heat pump on/off block start interval"),
+    "p_hp": (("s_hp", "u"), "W", "heat pump stage power"),
+    "hp_s_w": (("u", "s_hp"), "0..1", "SOS2 weight, heat pump"),
     # machines
-    "ma_start": ("m", "kw"),
-    "c_ma_kw": ("m", "kw"),
-    "c_ma_u": ("m", "u"),
+    "ma_start": (("m", "kw"), "bool", "machine starts this kwartier"),
+    "c_ma_kw": (("m", "kw"), "kWh", "machine consumption, per kwartier"),
+    "c_ma_u": (("m", "u"), "kWh", "machine consumption, per interval"),
+    # objective (bare Vars, registered under an empty index path)
+    "cost": ((), "€", "total cost, this run"),
+    "delivery": ((), "kWh", "total grid import, this run"),
+    "production": ((), "kWh", "total grid export, this run"),
 }
 
 # Containers that legitimately produce Var leaves but are deliberately not
@@ -1309,6 +1386,21 @@ SHAPES: dict[str, tuple[str, ...]] = {
 # non-interval container without that container silently vanishing from
 # every dump.
 SHAPES_IGNORE: frozenset[str] = frozenset()
+
+
+# Kleine accessors zodat de rest van de module niet overal de (assen,
+# eenheid, omschrijving)-tuple hoeft te ontleden.
+def _dims(name: str) -> tuple[str, ...]:
+    return SHAPES[name][0]
+
+
+def _unit(name: str) -> str:
+    return SHAPES[name][1]
+
+
+def _description(name: str) -> str:
+    return SHAPES[name][2]
+
 
 # Grouping used only for dump_interval's human-readable output — which
 # heading a container's values print under. Purely cosmetic: an unlisted
@@ -1370,6 +1462,9 @@ FAMILY: dict[str, str] = {
     "ma_start": "machine",
     "c_ma_kw": "machine",
     "c_ma_u": "machine",
+    "cost": "objective",
+    "delivery": "objective",
+    "production": "objective",
 }
 
 # Asset-index axes that get their own sub-heading in the text render
@@ -1377,42 +1472,53 @@ FAMILY: dict[str, str] = {
 _ASSET_AXES = ("b", "e", "m")
 
 
-# Faalt hard, met de namen van de onbekende containers, zodra de registry
-# een containernaam bevat die niet in SHAPES of SHAPES_IGNORE voorkomt —
-# dit is de "voeg een container toe zonder SHAPES bij te werken" val uit de
-# A3-testparagraaf.
-def _assert_shapes_complete(registry: dict) -> None:
-    names = {name for name, _ in registry.values()}
-    unknown = sorted(names - set(SHAPES) - SHAPES_IGNORE)
-    if unknown:
+# Faalt hard zodra de registry een containernaam bevat die niet in SHAPES of
+# SHAPES_IGNORE voorkomt, óf een SHAPES-entry zonder eenheid — beide zijn
+# dezelfde fout: dump_interval weet niet hoe hij de container moet tonen.
+def _assert_shapes_complete(registry_by_idx: dict) -> None:
+    names = {name for name, _ in registry_by_idx.values()}
+    missing = sorted(names - set(SHAPES) - SHAPES_IGNORE)
+    no_unit = sorted(name for name in names if name in SHAPES and not SHAPES[name][1])
+    problems = []
+    if missing:
+        problems.append(
+            f"{len(missing)} container(s) have no SHAPES entry and are not "
+            f"on SHAPES_IGNORE: {', '.join(missing)}"
+        )
+    if no_unit:
+        problems.append(
+            f"{len(no_unit)} container(s) have a SHAPES entry with no unit: "
+            f"{', '.join(no_unit)}"
+        )
+    if problems:
         raise VarRegistryError(
-            f"{len(unknown)} variable container(s) have no SHAPES entry "
-            f"and are not on SHAPES_IGNORE: {', '.join(unknown)}. "
-            f"calc_optimum() grew a new variable family; add its axis "
-            f"layout to SHAPES (or to SHAPES_IGNORE if it's deliberately "
-            f"not interval-addressable) in da_debug.py before dump can "
-            f"cover it."
+            "dump_interval cannot render every container in this registry: "
+            + "; ".join(problems)
+            + ". calc_optimum() grew a new variable family, or an existing "
+            "SHAPES entry is incomplete — add/complete it in da_debug.py "
+            "(or add it to SHAPES_IGNORE if it's deliberately not "
+            "interval-addressable) before dump can cover it."
         )
 
 
 # Groepeert de registry per containernaam, nodig omdat build_var_registry
 # zelf per var.idx sleutelt en dump_interval juist per container wil kunnen
 # selecteren.
-def _group_by_container(registry: dict) -> dict[str, list[tuple[tuple, int]]]:
+def _group_by_container(registry_by_idx: dict) -> dict[str, list[tuple[tuple, int]]]:
     groups: dict[str, list[tuple[tuple, int]]] = {}
-    for var_idx, (name, idx_tuple) in registry.items():
+    for var_idx, (name, idx_tuple) in registry_by_idx.items():
         groups.setdefault(name, []).append((idx_tuple, var_idx))
     return groups
 
 
-# Zoekt de interval-as van een SHAPES-vorm op: positie plus of het de
+# Zoekt de interval-as van een assen-tuple op: positie plus of het de
 # U+1-grensvariant (soc-achtig) is. Geeft None als de container geen
 # interval-as heeft (bv. cycle_cost, alleen per batterij).
-def _interval_axis(shape: tuple[str, ...]) -> Optional[tuple[int, bool]]:
-    if "u_boundary" in shape:
-        return shape.index("u_boundary"), True
-    if "u" in shape:
-        return shape.index("u"), False
+def _interval_axis(dims: tuple[str, ...]) -> Optional[tuple[int, bool]]:
+    if "u_boundary" in dims:
+        return dims.index("u_boundary"), True
+    if "u" in dims:
+        return dims.index("u"), False
     return None
 
 
@@ -1424,8 +1530,7 @@ def _select_at(entries: list[tuple[tuple, int]], axis_pos: int, wanted: set[int]
 
 # Bouwt eenmalig var.idx -> [constraint-index, ...] en cachet dat op het
 # model, zodat meerdere dump_interval-aanroepen tegen hetzelfde opgeloste
-# model de O(aantal constraints)-kost maar één keer betalen (§2.5, gemeten
-# 10ms bij 2304 constraints).
+# model de O(aantal constraints)-kost maar één keer betalen.
 def _inverse_var_constraint_index(model) -> dict[int, list[int]]:
     cached = getattr(model, "_debug_inv_index", None)
     if cached is not None:
@@ -1457,26 +1562,33 @@ def _is_binding(c, tol: float = 1e-6) -> bool:
     return abs(activity - rhs) < tol
 
 
-# Vertaalt een Var naar zijn leesbare label via de registry, of naar
-# var(idx) als de Var niet geregistreerd is (bv. de kale cost/delivery-
-# variabelen, die nooit in een list/tuple zaten en dus geen registry-entry
-# hebben — build_var_registry loopt bewust alleen door containers).
-def label_for_var(var, registry: dict) -> str:
-    entry = registry.get(var.idx)
+# Vertaalt een Var naar zijn leesbare, benoemde label via de registry
+# ("ac_from_dc_w[b=0][u=9][ds=5]" in plaats van positionele haakjes), of
+# naar var(idx) als de Var niet geregistreerd is.
+def label_for_var(var, registry_by_idx: dict) -> str:
+    entry = registry_by_idx.get(var.idx)
     if entry is None:
         return f"var({var.idx})"
     name, idx = entry
-    return name + "".join(f"[{i}]" for i in idx)
+    dims = SHAPES.get(name)
+    if not dims:
+        return name + "".join(f"[{i}]" for i in idx)
+    dim_names = dims[0]
+    parts = "".join(
+        f"[{dim_names[pos] if pos < len(dim_names) else '?'}={v}]"
+        for pos, v in enumerate(idx)
+    )
+    return name + parts
 
 
 _SENSE_SYMBOLS = {"<": "<=", ">": ">=", "=": "="}
 
 
-# Rendert een constraint met registry-labels in plaats van var(N)/constr(N),
-# bv. "ac_to_dc[0][14] - 0.95*dc_from_ac[0][14] = 0".
-def render_constraint(c, registry: dict) -> str:
+# Rendert een constraint met benoemde registry-labels in plaats van
+# var(N)/constr(N), bv. "ac_to_dc[b=0][u=14] - 0.95*dc_from_ac[b=0][u=14] = 0".
+def render_constraint(c, registry_by_idx: dict) -> str:
     terms = sorted(
-        ((coef, label_for_var(v, registry)) for v, coef in c.expr.expr.items()),
+        ((coef, label_for_var(v, registry_by_idx)) for v, coef in c.expr.expr.items()),
         key=lambda t: t[1],
     )
     pieces: list[str] = []
@@ -1495,32 +1607,35 @@ def render_constraint(c, registry: dict) -> str:
 
 
 # Elke actieve SOS2-curve in het model: (label, gewichtscontainer, as-naam
-# van de trap, container met de al-geïnterpoleerde waarde). python-mip
-# biedt geen manier om SOS-sets na add_sos() terug op te vragen, dus dit kan
-# alleen uit de gewichtsvariabelen zelf komen, niet uit constraint-inspectie
-# (§2.5). Drie sites, zie A0 Q7 / architectuurdoc §11: batterij laden,
-# batterij ontladen, warmtepomp (alleen aanwezig bij adjustment "power" /
-# "heating curve" — de "on/off"-tak gebruikt hp_bl_on zonder SOS2).
+# van de trap, container met de al-geïnterpoleerde waarde, AC-sample-array,
+# DC-sample-array). python-mip biedt geen manier om SOS-sets na add_sos()
+# terug op te vragen, dus dit kan alleen uit de gewichtsvariabelen zelf
+# komen, niet uit constraint-inspectie. Drie sites: batterij laden,
+# batterij ontladen, warmtepomp (alleen aanwezig bij adjustment
+# "power"/"heating curve" — de "on/off"-tak gebruikt hp_bl_on zonder SOS2).
+# De heat pump heeft geen sample-arrays.
 _SOS2_CURVES = (
-    ("battery charge", "ac_to_dc_w", "cs", "ac_to_dc"),
-    ("battery discharge", "ac_from_dc_w", "ds", "ac_from_dc"),
-    ("heat pump", "hp_s_w", "s_hp", "h_hp"),
+    ("battery charge", "ac_to_dc_w", "cs", "ac_to_dc", "ac_to_dc_samples", "dc_from_ac_samples"),
+    ("battery discharge", "ac_from_dc_w", "ds", "ac_from_dc", "ac_from_dc_samples", "dc_to_ac_samples"),
+    ("heat pump", "hp_s_w", "s_hp", "h_hp", None, None),
 )
 
 
 # Bouwt voor elke aanwezige SOS2-curve een rapport op interval u: welke
-# trappen actief zijn, of ze aangrenzend zijn, en de al-geïnterpoleerde
+# trappen actief zijn (met de bijbehorende AC/DC-sample als die er is),
+# of het er 0, 1 of 2-aangrenzend zijn (of een fout: meer dan 2, of
+# niet-aangrenzend), de som van de gewichten, en de al-geïnterpoleerde
 # waarde uit de bijbehorende vermogenscontainer.
-def _sos2_reports(model, registry: dict, u: int) -> list[dict]:
-    by_container = _group_by_container(registry)
+def _sos2_reports(model, registry_by_idx: dict, samples: dict, u: int) -> list[dict]:
+    by_container = _group_by_container(registry_by_idx)
     reports: list[dict] = []
-    for label, weight_name, stage_axis, power_name in _SOS2_CURVES:
+    for label, weight_name, stage_axis, power_name, ac_samples_name, dc_samples_name in _SOS2_CURVES:
         entries = by_container.get(weight_name)
         if not entries:
             continue  # this run didn't build this curve (e.g. hp on/off mode)
-        shape = SHAPES[weight_name]
-        u_pos = shape.index("u")
-        stage_pos = shape.index(stage_axis)
+        dims = _dims(weight_name)
+        u_pos = dims.index("u")
+        stage_pos = dims.index(stage_axis)
 
         groups: dict[tuple, dict[int, int]] = {}
         for idx_tuple, var_idx in entries:
@@ -1532,37 +1647,65 @@ def _sos2_reports(model, registry: dict, u: int) -> list[dict]:
             groups.setdefault(rest, {})[idx_tuple[stage_pos]] = var_idx
 
         power_by_key: dict[tuple, int] = {}
-        power_shape = SHAPES.get(power_name) if power_name else None
-        if power_name and power_shape and "u" in power_shape:
-            p_u_pos = power_shape.index("u")
+        power_dims = _dims(power_name) if power_name else None
+        if power_name and power_dims and "u" in power_dims:
+            p_u_pos = power_dims.index("u")
             for idx_tuple, var_idx in by_container.get(power_name, []):
                 if idx_tuple[p_u_pos] != u:
                     continue
                 rest = tuple(v for pos, v in enumerate(idx_tuple) if pos != p_u_pos)
                 power_by_key[rest] = var_idx
 
+        ac_samples = samples.get(ac_samples_name) if ac_samples_name else None
+        dc_samples = samples.get(dc_samples_name) if dc_samples_name else None
+
         for rest, stage_map in sorted(groups.items()):
             stages = sorted(stage_map.items())
             values = [(s, model.vars[vidx].x) for s, vidx in stages]
+            total_weight = sum(v for _s, v in values)
             nonzero = [(s, v) for s, v in values if abs(v) > 1e-9]
             indices = [s for s, _ in nonzero]
-            if len(indices) <= 1:
+            if len(indices) == 0:
+                case = "idle"
                 adjacent = True
-            elif len(indices) == 2:
-                adjacent = indices[1] - indices[0] == 1
+            elif len(indices) == 1:
+                case = "single"
+                adjacent = True
+            elif len(indices) == 2 and indices[1] - indices[0] == 1:
+                case = "interpolated"
+                adjacent = True
             else:
+                case = "error"
                 adjacent = False
+
+            active_stages = []
+            for s, v in nonzero:
+                ac_val = dc_val = None
+                try:
+                    if ac_samples is not None:
+                        ac_val = ac_samples[rest[0]][s] if rest else ac_samples[s]
+                    if dc_samples is not None:
+                        dc_val = dc_samples[rest[0]][s] if rest else dc_samples[s]
+                except (IndexError, TypeError):
+                    ac_val = dc_val = None
+                active_stages.append(
+                    {"stage": s, "weight": v, "ac_sample": ac_val, "dc_sample": dc_val}
+                )
+
             interp_idx = power_by_key.get(rest)
             reports.append(
                 {
                     "curve": label,
                     "asset": rest,
                     "weights": values,
-                    "active_stages": nonzero,
+                    "active_stages": active_stages,
+                    "total_weight": total_weight,
+                    "case": case,
                     "adjacent": adjacent,
                     "interpolated": model.vars[interp_idx].x
                     if interp_idx is not None
                     else None,
+                    "interpolated_unit": _unit(power_name) if power_name else None,
                 }
             )
     return reports
@@ -1570,67 +1713,467 @@ def _sos2_reports(model, registry: dict, u: int) -> list[dict]:
 
 # Bouwt de sectiesleutel voor de tekstuitvoer: "battery 0", "ev 1", of
 # gewoon "boiler"/"grid" als de container geen asset-as heeft. Neemt de
-# echte indexwaarde uit idx_tuple, niet de as-naam — anders zouden batterij
-# 0 en batterij 1 onder dezelfde sleutel samenvloeien.
-def _section_key(name: str, shape: tuple[str, ...], idx_tuple: tuple) -> str:
+# echte indexwaarde uit rest[0], niet de as-naam — anders zouden batterij 0
+# en batterij 1 onder dezelfde sleutel samenvloeien. Werkt zowel voor een
+# volledige idx_tuple als voor een "rest"-tuple zonder de interval-as, mits
+# de asset-as (indien aanwezig) altijd op positie 0 staat — waar in elke
+# SHAPES-entry hier het geval is.
+def _section_key(name: str, dims: tuple[str, ...], idx_or_rest: tuple) -> str:
     family = FAMILY.get(name, "other")
-    if shape and shape[0] in _ASSET_AXES:
-        return f"{family} {idx_tuple[0]}"
+    if dims and dims[0] in _ASSET_AXES and idx_or_rest:
+        return f"{family} {idx_or_rest[0]}"
     return family
 
 
-# Kernfunctie van A3 (§2.5): alles wat het opgeloste model wist over
-# interval u — elke variabele met leesbaar label, welke constraints
-# bindend zijn, en de SOS2-status van elke aanwezige piecewise-curve.
+# Vindt de var.idx van een kaal geregistreerde Var (leeg indexpad) onder de
+# gegeven containernaam — gebruikt om "cost" te lokaliseren voor de
+# objective-attributie.
+def _find_scalar_idx(registry_by_idx: dict, name: str) -> Optional[int]:
+    for idx, (n, path) in registry_by_idx.items():
+        if n == name and path == ():
+            return idx
+    return None
+
+
+# Loopt de definiërende gelijkheid van `cost` af (niet de
+# objective zelf, die voor "minimize cost" slechts de kale variabele is en
+# dus geen enkele per-interval informatie draagt) en trekt daaruit elke
+# term die interval u daadwerkelijk raakt. Twee soorten termen dragen bij:
+# (a) een term met een eigen interval-as (c_l[u], c_t[u], soc_mid[b][0/U],
+# ...), direct toegerekend; (b) een term zonder interval-as — een
+# per-asset accumulator als cycle_cost[b] of low_soc_penalty[e] — die zelf
+# door precies één andere constraint wordt gedefinieerd (gevonden via de
+# inverse index, niet aangenomen), één laag dieper afgelopen voor diens
+# eigen u-geïndexeerde termen. Deze keten wordt structureel ontdekt, niet
+# hardgecodeerd naar de huidige formule — geverifieerd tegen een dump van
+# een echte config (1 batterij, 2 EV's): cycle_cost/penalty_cost/
+# switch_cost/low_soc_penalty lossen alle in precies één stap op; switch_cost
+# blijkt daarbij zelf geen interval-as te bevatten (het hangt af van
+# ev_start_stops_sum, een teller zonder u-as) en draagt dus terecht niets
+# bij aan geen enkel interval.
+def _objective_attribution(model, registry_by_idx: dict, u: int) -> tuple[list[dict], float]:
+    cost_idx = _find_scalar_idx(registry_by_idx, "cost")
+    if cost_idx is None:
+        return [], 0.0
+    inv = _inverse_var_constraint_index(model)
+    cost_constrs = inv.get(cost_idx, [])
+    if not cost_constrs:
+        return [], 0.0
+    definition_ci = cost_constrs[0]
+    definition = model.constrs[definition_ci]
+    cost_var = model.vars[cost_idx]
+
+    terms = dict(definition.expr.expr)
+    cost_coef = terms.pop(cost_var, None)
+    if not cost_coef:
+        return [], 0.0
+
+    contributions: list[dict] = []
+
+    # Levert True (en voegt een bijdrage toe) als `var` zelf een
+    # interval-as heeft die exact interval u is. Bewust altijd exact-u,
+    # ook voor een u_boundary-container: de {u, u+1}-paarweergave uit de
+    # sections-opbouw is een leesbaarheidskeuze voor die ene grenswaarde
+    # ("start en eind van interval u samen tonen"), maar een
+    # u_boundary-variabele die als losse term in een per-u som voorkomt
+    # (zoals soc_low[b][u] in penalty_cost's definitie) hoort met index u
+    # bij interval u en met index u+1 bij interval u+1 — nooit bij allebei.
+    # {u, u+1} hier zou soc_low[b][u+1]'s eigen bijdrage dubbel toerekenen:
+    # aan interval u (als "buurwaarde") én aan interval u+1 (als directe
+    # term daar).
+    def _direct(var, coef) -> bool:
+        entry = registry_by_idx.get(var.idx)
+        if entry is None:
+            return False
+        name, idx_tuple = entry
+        if name not in SHAPES:
+            return False
+        axis = _interval_axis(_dims(name))
+        if axis is None:
+            return False
+        axis_pos, _is_boundary = axis
+        if idx_tuple[axis_pos] != u:
+            return False
+        effective_coef = -coef / cost_coef + 0.0  # normalise -0.0
+        contributions.append(
+            {
+                "label": label_for_var(var, registry_by_idx),
+                "unit": _unit(name),
+                "coef": effective_coef,
+                "value": var.x,
+                "contribution": effective_coef * var.x + 0.0,  # normalise -0.0
+            }
+        )
+        return True
+
+    for var, coef in terms.items():
+        if _direct(var, coef):
+            continue
+        # One-hop chain: var itself carries no interval axis. If it is
+        # defined by exactly one other constraint, walk that constraint's
+        # own terms for interval-u contributions.
+        other = [ci for ci in inv.get(var.idx, []) if ci != definition_ci]
+        if len(other) != 1:
+            continue
+        inner = model.constrs[other[0]]
+        inner_terms = dict(inner.expr.expr)
+        inner_coef_for_var = inner_terms.pop(var, None)
+        if not inner_coef_for_var:
+            continue
+        for ivar, icoef in inner_terms.items():
+            ientry = registry_by_idx.get(ivar.idx)
+            if ientry is None:
+                continue
+            iname, iidx = ientry
+            if iname not in SHAPES:
+                continue
+            iaxis = _interval_axis(_dims(iname))
+            if iaxis is None:
+                continue
+            iaxis_pos, _iis_boundary = iaxis
+            if iidx[iaxis_pos] != u:  # same exact-u reasoning as _direct() above
+                continue
+            effective_coef = (coef / cost_coef) * (icoef / inner_coef_for_var) + 0.0  # normalise -0.0
+            contributions.append(
+                {
+                    "label": label_for_var(ivar, registry_by_idx),
+                    "unit": _unit(iname),
+                    "coef": effective_coef,
+                    "value": ivar.x,
+                    "contribution": effective_coef * ivar.x + 0.0,  # normalise -0.0
+                }
+            )
+
+    contributions.sort(key=lambda c: c["label"])
+    net = sum(c["contribution"] for c in contributions) + 0.0  # normalise -0.0
+    return contributions, net
+
+
+# Probeert een constraint volledig samen te vatten tot één
+# Σ-regel — precies één (containernaam, rest-index)-groep, allemaal
+# dezelfde coëfficiënt, een aaneengesloten reeks intervallen van minstens 3
+# lang, die *alle* termen van de constraint dekt. Geeft None als dat niet
+# lukt (gemengde containers/coëfficiënten, een korte of niet-aaneengesloten
+# reeks); de aanroeper valt dan terug op een andere weergave — nooit falen.
+def _try_sigma_collapse(c, registry_by_idx: dict) -> Optional[str]:
+    groups: dict[tuple, dict[int, float]] = {}
+    for v, coef in c.expr.expr.items():
+        entry = registry_by_idx.get(v.idx)
+        if entry is None:
+            return None
+        name, idx_tuple = entry
+        if name not in SHAPES:
+            return None
+        axis = _interval_axis(_dims(name))
+        if axis is None or axis[1]:  # no interval axis, or a boundary axis
+            return None
+        axis_pos = axis[0]
+        u_val = idx_tuple[axis_pos]
+        rest = tuple(v2 for pos, v2 in enumerate(idx_tuple) if pos != axis_pos)
+        groups.setdefault((name, rest), {})[u_val] = coef
+
+    if len(groups) != 1:
+        return None
+    (name, rest), u_coefs = next(iter(groups.items()))
+    coefs = set(u_coefs.values())
+    if len(coefs) != 1:
+        return None
+    u_values = sorted(u_coefs)
+    if len(u_values) < 3 or u_values != list(range(u_values[0], u_values[-1] + 1)):
+        return None
+
+    coef = next(iter(coefs))
+    magnitude = abs(coef)
+    coef_str = "" if abs(magnitude - 1) < 1e-12 else f"{magnitude:g}*"
+    sign = "-" if coef < 0 else ""
+    dim_names = _dims(name)
+    axis_pos = _interval_axis(dim_names)[0]
+    rest_dims = [d for pos, d in enumerate(dim_names) if pos != axis_pos]
+    label = name + "".join(f"[{d}={v}]" for d, v in zip(rest_dims, rest)) + "[u]"
+    rhs = -c.expr.const + 0.0
+    sense = _SENSE_SYMBOLS.get(c.expr.sense, c.expr.sense)
+    return (
+        f"Σ_{{u={u_values[0]}..{u_values[-1]}}} {sign}{coef_str}{label} "
+        f"{sense} {rhs:g}"
+    )
+
+
+# Herkenbare naam per constraint-"signatuur" (de verzameling
+# containernamen die erin voorkomen) — model-onafhankelijk van u, dus
+# dezelfde tabel dekt elke interval-instantie van dat constraint-type.
+# Overgenomen letterlijk uit een dump van een echte config (1 batterij,
+# 2 EV's, 2 machines) — niet geraden: elk van deze 21 signaturen kwam
+# daadwerkelijk voor. De AC-energiebalans-signatuur verandert mee met welke
+# assets aanwezig zijn (geen c_ev-term bij 0 EV's, etc.); een config met
+# een andere combinatie mist dan gewoon deze ene match en valt terug op de
+# ongelabelde weergave — verwacht gedrag, geen bug: een niet-matchende rij
+# moet nooit een fout opleveren, alleen ongelabeld blijven.
+_CONSTRAINT_PATTERNS: dict[frozenset, str] = {
+    frozenset({"soc", "soc_low", "soc_mid"}): "SoC low/mid split",
+    frozenset({"ac_to_dc_w"}): "SOS2 convexity (battery charge)",
+    frozenset({"ac_to_dc", "ac_to_dc_w"}): "SOS2 AC power definition (battery charge)",
+    frozenset({"ac_to_dc_w", "dc_from_ac"}): "SOS2 DC power definition (battery charge)",
+    frozenset({"ac_from_dc_w"}): "SOS2 convexity (battery discharge, <=1)",
+    frozenset({"ac_from_dc", "ac_from_dc_w"}): "SOS2 AC power definition (battery discharge)",
+    frozenset({"ac_from_dc_w", "dc_to_ac"}): "SOS2 DC power definition (battery discharge)",
+    frozenset({"dc_from_bat", "dc_to_bat", "soc"}): "SoC balance u→u+1",
+    frozenset({"pv_dc_on_off", "pv_prod_dc_sum"}): "DC-coupled PV production sum",
+    frozenset({"dc_from_ac", "dc_from_bat", "dc_to_ac", "dc_to_bat", "pv_prod_dc_sum"}): "DC bus balance",
+    frozenset({"ac_to_dc_on", "dc_from_ac"}): "charge power <= on*max",
+    frozenset({"ac_from_dc", "ac_from_dc_on"}): "discharge power <= on*max",
+    frozenset({"ac_from_dc_on", "ac_to_dc_on"}): "charge/discharge mutual exclusion",
+    frozenset({"c_l", "c_l_on"}): "grid import <= on*max",
+    frozenset({"c_t", "c_t_on"}): "grid export <= on*max",
+    frozenset({"c_l_on", "c_t_on"}): "grid import/export exclusion",
+    frozenset({"ac_from_dc", "ac_to_dc", "c_b", "c_ev", "c_hp", "c_l", "c_ma_u", "c_t"}): "AC energy balance",
+    frozenset({"ev_start_stops_sum", "switch_cost"}): "EV switch-cost definition",
+    frozenset({"low_soc_penalty", "low_soc_penalty_int"}): "EV low-SoC penalty definition",
+    frozenset({"cycle_cost", "dc_from_bat", "dc_to_bat"}): "battery cycle-cost definition",
+    frozenset({"penalty_cost", "soc_low"}): "battery low-SoC penalty definition",
+}
+
+
+# Bouwt de containernaam-signatuur van een constraint (ongeregistreerde
+# vars tellen mee als hun eigen var(N), zodat een signatuur nooit stil
+# onvolledig is).
+def _constraint_signature(c, registry_by_idx: dict) -> frozenset:
+    names = set()
+    for v in c.expr.expr:
+        entry = registry_by_idx.get(v.idx)
+        names.add(entry[0] if entry else f"var({v.idx})")
+    return frozenset(names)
+
+
+def _match_pattern(c, registry_by_idx: dict) -> Optional[str]:
+    return _CONSTRAINT_PATTERNS.get(_constraint_signature(c, registry_by_idx))
+
+
+# Geeft de interval-index van één losse Var terug (via zijn eigen
+# interval-as), of None als de Var niet geregistreerd is of geen
+# interval-as heeft (bv. cycle_cost[b]).
+def _term_interval(var, registry_by_idx: dict) -> Optional[int]:
+    entry = registry_by_idx.get(var.idx)
+    if entry is None:
+        return None
+    name, idx_tuple = entry
+    if name not in SHAPES:
+        return None
+    axis = _interval_axis(_dims(name))
+    if axis is None:
+        return None
+    return idx_tuple[axis[0]]
+
+
+# Alle interval-waarden die deze constraint daadwerkelijk raakt (via elke
+# term met een eigen interval-as); een term zonder interval-as draagt hier
+# niets aan bij.
+def _touched_u_values(c, registry_by_idx: dict) -> set:
+    touched = set()
+    for v in c.expr.expr:
+        iv = _term_interval(v, registry_by_idx)
+        if iv is not None:
+            touched.add(iv)
+    return touched
+
+
+# "local" = elke term die een interval-as heeft, raakt alleen u of
+# de grenspartner u+1. Alles daarbuiten is "global" — bindend, maar zonder
+# lokale informatie over interval u.
+def _is_local(c, registry_by_idx: dict, u: int) -> bool:
+    return _touched_u_values(c, registry_by_idx) <= {u, u + 1}
+
+
+# Een lokale constraint van de vorm "één variabele == 0" — een
+# inactieve asset die voor dit interval op nul is vastgezet. Wordt apart
+# gegroepeerd in plaats van los afgedrukt.
+def _pinned_zero_label(c, registry_by_idx: dict) -> Optional[str]:
+    if c.expr.sense != "=":
+        return None
+    terms = list(c.expr.expr.items())
+    if len(terms) != 1:
+        return None
+    rhs = -c.expr.const + 0.0
+    if abs(rhs) > 1e-9:
+        return None
+    v, _coef = terms[0]
+    return label_for_var(v, registry_by_idx)
+
+
+# Kernfunctie: alles wat het opgeloste model wist over interval u — elke
+# variabele met leesbaar, benoemd label en eenheid, de SOS2-status van elke
+# aanwezige piecewise-curve, welke constraints bindend zijn (lokaal in
+# volle vorm, globaal als één samengevatte regel, nul-vastzettingen
+# gegroepeerd), en de bijdrage van elke interval-u-term aan de objective.
 # Geeft een structuur terug (geen platte tekst) zodat zowel de tekst- als
 # de --json-weergave van de CLI op dezelfde data werken.
-def dump_interval(model, registry: dict, u: int, *, header: Optional[dict] = None) -> dict:
-    """Everything the solved model knew about interval ``u``: every
-    registered variable touching it, which constraints on it are actually
-    binding, and the SOS2 active-stage/adjacency state for every piecewise
-    curve present in this run. Raises ``VarRegistryError`` if the registry
-    contains a container ``SHAPES`` doesn't know about (§2.5's completeness
-    assertion — a silent gap here is worse than a loud failure, since it
-    would just quietly omit part of the model from every dump)."""
-    _assert_shapes_complete(registry)
-    by_container = _group_by_container(registry)
+def dump_interval(
+    model,
+    registry: VarRegistry,
+    u: int,
+    *,
+    header: Optional[dict] = None,
+    battery_capacity: Optional[list] = None,
+) -> dict:
+    """Everything the solved model knew about interval ``u``. Raises
+    ``VarRegistryError`` if the registry contains a container ``SHAPES``
+    doesn't know about, or knows about but has no unit for — a silent gap
+    here is worse than a loud failure, since it would just quietly omit or
+    mis-render part of the model from every dump. ``battery_capacity`` is
+    an optional list of kWh capacities indexed by battery, used only to
+    add a kWh estimate next to each battery's %-based SoC delta; omit it
+    and the delta still renders, just without the kWh figure."""
+    by_idx = registry.by_idx
+    samples = registry.samples
+    _assert_shapes_complete(by_idx)
+    by_container = _group_by_container(by_idx)
 
     sections: dict[str, list[dict]] = {}
-    touched_vars: set[int] = set()
+    touched_vars: set = set()
+
     for name, entries in by_container.items():
-        shape = SHAPES[name]
-        axis = _interval_axis(shape)
+        dims = _dims(name)
+        axis = _interval_axis(dims)
         if axis is None:
             continue  # no interval axis at all (e.g. cycle_cost[b])
         axis_pos, is_boundary = axis
-        wanted = {u, u + 1} if is_boundary else {u}
-        matches = _select_at(entries, axis_pos, wanted)
-        for idx_tuple, var_idx in matches:
-            touched_vars.add(var_idx)
-            section_key = _section_key(name, shape, idx_tuple)
-            sections.setdefault(section_key, []).append(
-                {
-                    "label": name + "".join(f"[{i}]" for i in idx_tuple),
+        unit = _unit(name)
+
+        if is_boundary:
+            by_rest: dict[tuple, dict[int, int]] = {}
+            for idx_tuple, var_idx in entries:
+                u_val = idx_tuple[axis_pos]
+                if u_val not in (u, u + 1):
+                    continue
+                rest = tuple(v for pos, v in enumerate(idx_tuple) if pos != axis_pos)
+                by_rest.setdefault(rest, {})[u_val] = var_idx
+            dim_names = dims
+            rest_dims = [d for pos, d in enumerate(dim_names) if pos != axis_pos]
+            for rest, u_map in by_rest.items():
+                if u not in u_map:
+                    continue
+                var_in = u_map[u]
+                touched_vars.add(var_in)
+                value_in = model.vars[var_in].x
+                value_out = None
+                if (u + 1) in u_map:
+                    var_out = u_map[u + 1]
+                    touched_vars.add(var_out)
+                    value_out = model.vars[var_out].x
+                delta = (value_out - value_in) if value_out is not None else None
+                row = {
+                    "kind": "boundary",
+                    "label": name + "".join(f"[{d}={v}]" for d, v in zip(rest_dims, rest)),
                     "container": name,
-                    "index": idx_tuple,
-                    "value": model.vars[var_idx].x,
-                    "is_boundary_partner": is_boundary and idx_tuple[axis_pos] == u + 1,
+                    "unit": unit,
+                    "value_in": value_in,
+                    "value_out": value_out,
+                    "delta": delta,
                 }
-            )
+                if (
+                    name in ("soc", "soc_low", "soc_mid")
+                    and battery_capacity
+                    and rest
+                    and delta is not None
+                    and 0 <= rest[0] < len(battery_capacity)
+                ):
+                    one_soc = battery_capacity[rest[0]] / 100.0
+                    row["delta_kwh"] = delta * one_soc
+                section_key = _section_key(name, dims, rest)
+                sections.setdefault(section_key, []).append(row)
+        else:
+            matches = _select_at(entries, axis_pos, {u})
+            for idx_tuple, var_idx in matches:
+                touched_vars.add(var_idx)
+                section_key = _section_key(name, dims, idx_tuple)
+                sections.setdefault(section_key, []).append(
+                    {
+                        "kind": "scalar",
+                        "label": name + "".join(
+                            f"[{d}={v}]" for d, v in zip(dims, idx_tuple)
+                        ),
+                        "container": name,
+                        "unit": unit,
+                        "value": model.vars[var_idx].x,
+                    }
+                )
+
     for entries in sections.values():
         entries.sort(key=lambda e: e["label"])
 
-    sos2 = _sos2_reports(model, registry, u)
+    sos2 = _sos2_reports(model, by_idx, samples, u)
 
+    # Objective attribution reads cost's own definition constraint, not
+    # the general constraint set below — deliberately excluded from
+    # "constraints" entirely and shown as its own section instead, since
+    # it's the largest row in the model and printing it as a regular
+    # constraint would bury everything else.
+    objective_contributions, objective_net = _objective_attribution(model, by_idx, u)
+    price_mismatch = None
+    header = dict(header) if header else {}
+    price_cons = header.get("price_cons")
+    price_prod = header.get("price_prod")
+    for contrib in objective_contributions:
+        if contrib["label"].startswith("c_l[") and price_cons is not None:
+            if abs(contrib["coef"] - price_cons) > 1e-4:
+                price_mismatch = (
+                    f"c_l coefficient {contrib['coef']:.6f} != header price_cons "
+                    f"{price_cons:.6f}"
+                )
+        if contrib["label"].startswith("c_t[") and price_prod is not None:
+            if abs(contrib["coef"] - (-price_prod)) > 1e-4:
+                price_mismatch = (
+                    f"c_t coefficient {contrib['coef']:.6f} != -header price_prod "
+                    f"{-price_prod:.6f}"
+                )
+
+    cost_idx = _find_scalar_idx(by_idx, "cost")
     inv = _inverse_var_constraint_index(model)
-    constraint_ids = sorted({ci for vidx in touched_vars for ci in inv.get(vidx, [])})
-    binding_constraints = [
-        {"index": ci, "text": render_constraint(model.constrs[ci], registry)}
-        for ci in constraint_ids
-        if _is_binding(model.constrs[ci])
-    ]
+    cost_definition_ci = inv.get(cost_idx, [None])[0] if cost_idx is not None else None
 
-    # Reduced-detail neighbour context (§2.5 / A3 testing): SoC and
+    constraint_ids = sorted({ci for vidx in touched_vars for ci in inv.get(vidx, [])})
+    local_constraints: list[dict] = []
+    global_constraints: list[dict] = []
+    pinned_zero: list[str] = []
+    for ci in constraint_ids:
+        if ci == cost_definition_ci:
+            continue  # shown as objective attribution instead
+        c = model.constrs[ci]
+        if not _is_binding(c):
+            continue
+        if _is_local(c, by_idx, u):
+            pin_label = _pinned_zero_label(c, by_idx)
+            if pin_label is not None:
+                pinned_zero.append(pin_label)
+                continue
+            pattern = _match_pattern(c, by_idx)
+            local_constraints.append(
+                {
+                    "index": ci,
+                    "pattern": pattern,
+                    "text": render_constraint(c, by_idx),
+                }
+            )
+        else:
+            sigma = _try_sigma_collapse(c, by_idx)
+            pattern = _match_pattern(c, by_idx)
+            own_coef = next(
+                (
+                    coef
+                    for v, coef in c.expr.expr.items()
+                    if _term_interval(v, by_idx) == u
+                ),
+                None,
+            )
+            global_constraints.append(
+                {
+                    "index": ci,
+                    "pattern": pattern,
+                    "sigma": sigma,
+                    "own_term_coef": own_coef,
+                }
+            )
+
+    # Reduced-detail neighbour context: SoC and
     # top-level charge/discharge only, no on/off flags, no SOS2, no
     # constraints — just enough to see the trend across the interval.
     context_names = ("soc", "ac_to_dc", "ac_from_dc", "c_hp", "c_ev", "c_b")
@@ -1643,17 +2186,20 @@ def dump_interval(model, registry: dict, u: int, *, header: Optional[dict] = Non
             entries = by_container.get(name)
             if not entries:
                 continue
-            shape = SHAPES[name]
-            axis = _interval_axis(shape)
+            dims = _dims(name)
+            axis = _interval_axis(dims)
             if axis is None:
                 continue
             axis_pos, _is_boundary = axis
             matches = _select_at(entries, axis_pos, {neighbour})
             for idx_tuple, var_idx in matches:
-                section_key = _section_key(name, shape, idx_tuple)
+                section_key = _section_key(name, dims, idx_tuple)
                 neighbour_sections.setdefault(section_key, []).append(
                     {
-                        "label": name + "".join(f"[{i}]" for i in idx_tuple),
+                        "label": name + "".join(
+                            f"[{d}={v}]" for d, v in zip(dims, idx_tuple)
+                        ),
+                        "unit": _unit(name),
                         "value": model.vars[var_idx].x,
                     }
                 )
@@ -1664,17 +2210,25 @@ def dump_interval(model, registry: dict, u: int, *, header: Optional[dict] = Non
 
     return {
         "interval": u,
-        "header": dict(header) if header else {},
+        "header": header,
         "sections": sections,
         "sos2": sos2,
-        "binding_constraints": binding_constraints,
+        "local_constraints": local_constraints,
+        "global_constraints": global_constraints,
+        "pinned_zero": pinned_zero,
+        "objective_contributions": objective_contributions,
+        "objective_net": objective_net,
+        "objective_price_mismatch": price_mismatch,
         "context": context,
     }
 
 
 # Formatteert de structuur van dump_interval() als leesbare platte tekst
-# voor stdout; --json op de CLI gebruikt de structuur direct.
-def _format_dump_text(data: dict) -> str:
+# voor stdout; --json op de CLI gebruikt de structuur direct. `show_all`
+# schakelt de onderdrukking van exact-nul waarden uit (CLI --all) — een
+# puur presentatie-keuze, dump_interval() zelf levert altijd de volle,
+# ongefilterde data.
+def _format_dump_text(data: dict, show_all: bool = False) -> str:
     lines: list[str] = []
     header_bits = [f"interval {data['interval']}"]
     for k, v in data.get("header", {}).items():
@@ -1684,25 +2238,95 @@ def _format_dump_text(data: dict) -> str:
 
     for section_name in sorted(data["sections"]):
         entries = data["sections"][section_name]
-        lines.append(f"  {section_name}")
+        rendered_rows = []
         for e in entries:
-            arrow = " (boundary)" if e.get("is_boundary_partner") else ""
-            lines.append(f"    {e['label']:<28} {e['value']:.4f}{arrow}")
+            if e["kind"] == "scalar":
+                if not show_all and abs(e["value"]) < 1e-9:
+                    continue
+                rendered_rows.append(f"    {e['label']:<28} {e['value']:.4f} {e['unit']}")
+            else:  # boundary
+                is_trivial = abs(e["value_in"]) < 1e-9 and (
+                    e["value_out"] is None or abs(e["value_out"]) < 1e-9
+                )
+                if not show_all and is_trivial:
+                    continue
+                out_str = f"{e['value_out']:.4f}" if e["value_out"] is not None else "?"
+                delta_str = f"  Δ{e['delta']:+.4f} {e['unit']}" if e["delta"] is not None else ""
+                kwh_str = f"  ≈ {e['delta_kwh']:+.4f} kWh" if "delta_kwh" in e else ""
+                rendered_rows.append(
+                    f"    {e['label']:<12} {e['value_in']:.4f} → {out_str} {e['unit']}"
+                    f"{delta_str}{kwh_str}"
+                )
+        if not rendered_rows:
+            if not show_all and entries:
+                lines.append(f"  {section_name}: idle ({len(entries)} variables, all zero)")
+            continue
+        lines.append(f"  {section_name}")
+        lines.extend(rendered_rows)
 
     if data["sos2"]:
         lines.append("  SOS2 curves")
         for r in data["sos2"]:
             asset = f" {r['asset']}" if r["asset"] else ""
-            stages = ", ".join(f"stage {s} (w={v:.4f})" for s, v in r["active_stages"])
-            if not stages:
+            if r["case"] == "idle":
                 stages = "no active stage"
-            flag = "ok" if r["adjacent"] else "NON-ADJACENT — solver-correctness signal"
-            interp = f"  interpolated={r['interpolated']:.4f}" if r["interpolated"] is not None else ""
-            lines.append(f"    {r['curve']}{asset}: {stages}  [adjacent: {flag}]{interp}")
+            else:
+                pieces = []
+                for st in r["active_stages"]:
+                    sample = ""
+                    if st["ac_sample"] is not None and st["dc_sample"] is not None:
+                        sample = f" → {st['ac_sample']:.3g} kW AC / {st['dc_sample']:.3g} kW DC"
+                    pieces.append(f"stage {st['stage']} (w={st['weight']:.4f}){sample}")
+                stages = ", ".join(pieces)
+            case_label = {
+                "idle": "idle",
+                "single": "1 stage active",
+                "interpolated": "2 adjacent stages (interpolated)",
+                "error": "NON-ADJACENT — solver-correctness signal",
+            }[r["case"]]
+            sum_note = ""
+            if r["case"] != "idle" and r["total_weight"] < 1 - 1e-6:
+                sum_note = f"  (Σw={r['total_weight']:.4f} < 1)"
+            interp = ""
+            if r["interpolated"] is not None:
+                interp = f"  interpolated={r['interpolated']:.4f} {r['interpolated_unit']}"
+            lines.append(f"    {r['curve']}{asset}: {case_label}: {stages}{sum_note}{interp}")
 
-    lines.append(f"  binding constraints ({len(data['binding_constraints'])})")
-    for bc in data["binding_constraints"]:
-        lines.append(f"    {bc['text']}")
+    if data["local_constraints"]:
+        lines.append(f"  local constraints ({len(data['local_constraints'])})")
+        for lc in data["local_constraints"]:
+            prefix = f"[{lc['pattern']}] " if lc["pattern"] else ""
+            lines.append(f"    {prefix}{lc['text']}")
+
+    if data["global_constraints"]:
+        lines.append(f"  global constraints touching u={data['interval']} ({len(data['global_constraints'])})")
+        for gc in data["global_constraints"]:
+            if gc["sigma"]:
+                lines.append(f"    {gc['sigma']}")
+            else:
+                label = gc["pattern"] or f"constraint {gc['index']}"
+                coef_str = f"{gc['own_term_coef']:g}" if gc["own_term_coef"] is not None else "?"
+                lines.append(f"    [{label}]  coef on u={data['interval']} term: {coef_str}")
+
+    if data["pinned_zero"]:
+        shown = data["pinned_zero"][:12]
+        more = len(data["pinned_zero"]) - len(shown)
+        tail = f", +{more} more" if more > 0 else ""
+        lines.append(
+            f"  pinned to zero ({len(data['pinned_zero'])}): {', '.join(shown)}{tail}"
+        )
+
+    if data["objective_contributions"]:
+        lines.append(f"  objective contribution, u={data['interval']}")
+        for c in data["objective_contributions"]:
+            lines.append(
+                f"    {c['label']:<18} {c['coef']:+.6g} €/{c['unit']} "
+                f"× {c['value']:.4f} {c['unit']} = {c['contribution']:+.4f} €"
+            )
+        lines.append("    ----")
+        lines.append(f"    net{'':<33}= {data['objective_net']:+.4f} €")
+        if data["objective_price_mismatch"]:
+            lines.append(f"    WARNING: {data['objective_price_mismatch']}")
 
     for neighbour, sections in data.get("context", {}).items():
         if not sections:
@@ -1710,13 +2334,12 @@ def _format_dump_text(data: dict) -> str:
         lines.append(f"  context u={neighbour}")
         for section_name in sorted(sections):
             for e in sections[section_name]:
-                lines.append(f"    {e['label']:<28} {e['value']:.4f}")
+                lines.append(f"    {e['label']:<28} {e['value']:.4f} {e['unit']}")
 
     return "\n".join(lines)
 
-
 # ---------------------------------------------------------------------------
-# CLI (A6, §13)
+# CLI
 # ---------------------------------------------------------------------------
 #
 # `python -m dao.prog.da_debug <command>` — run from anywhere the `dao`
@@ -1740,7 +2363,7 @@ class UsageError(Exception):
 
 class HermeticityViolation(RuntimeError):
     """Raised when a replayed run reaches for the network while ``--offline``
-    (the default for ``replay``) is in effect. §13.2: this is what turns
+    (the default for ``replay``) is in effect. This is what turns
     "the operator happened to be on the right machine" into something the
     tool itself proves on every run."""
 
@@ -1860,7 +2483,7 @@ def _find_unredacted_secrets(value: Any, path: str = "") -> list[str]:
 
 # Laadt een live options.json via een wegwerpkopie (nooit het origineel) en vergelijkt de confighash met die van de snapshot.
 def _check_config_drift(config_path_str: str, stored_hash: Optional[str]) -> dict:
-    """§13.4: copy-then-load. Never opens the real config file for writing,
+    """Copy-then-load: never opens the real config file for writing,
     and asserts (not just assumes) that it comes out byte-identical."""
     import shutil
     import tempfile
@@ -2336,22 +2959,151 @@ def _lookup_price_at_interval(
 # Zoekt de hoogste interval-index die daadwerkelijk in de registry
 # voorkomt, om --interval tegen een zinnig bereik te kunnen valideren
 # zonder dat de CLI U apart hoeft te kennen.
-def _max_known_interval(registry: dict) -> int:
+def _max_known_interval(registry_by_idx: dict) -> int:
     max_u = -1
-    for _var_idx, (name, idx_tuple) in registry.items():
-        shape = SHAPES.get(name)
-        if not shape:
+    for _var_idx, (name, idx_tuple) in registry_by_idx.items():
+        if name not in SHAPES:
             continue
-        if "u" in shape:
-            max_u = max(max_u, idx_tuple[shape.index("u")])
-        elif "u_boundary" in shape:
-            max_u = max(max_u, idx_tuple[shape.index("u_boundary")] - 1)
+        dims = _dims(name)
+        if "u" in dims:
+            max_u = max(max_u, idx_tuple[dims.index("u")])
+        elif "u_boundary" in dims:
+            max_u = max(max_u, idx_tuple[dims.index("u_boundary")] - 1)
     return max_u
 
 
-# Speelt een snapshot af met _debug_capture_vars aan, zodat A1's hook in
-# day_ahead.py de variabele-registry opbouwt, en dumpt daarna interval
-# --interval: alles wat het opgeloste model erover wist.
+# Een INTEGER- of BINARY-variabele die in nul constraints voorkomt — een
+# SOS2-plus-dangling-column-combinatie die bepaalde CBC-builds laat
+# crashen (bevestigd: cbcbox 2.935 crasht 3/3 op een dangling INTEGER;
+# cbcbox 2.929, de gepinde versie van de addon, niet). Een
+# geheel-model-eigenschap, in tegenstelling tot dump_interval, dat alleen
+# constraints ziet die één interval raken — en een container zonder
+# interval-as (zoals ev_partial_sum) sowieso nooit toont, ongeacht welk
+# interval je opvraagt. Hergebruikt dezelfde inverse index als
+# dump_interval's binding-constraints-check, alleen nu over het hele model
+# in plaats van gefilterd op één u.
+def _find_dangling_int_columns(model, registry_by_idx: dict) -> dict:
+    inv = _inverse_var_constraint_index(model)
+    dangling: dict[str, list[dict]] = {"I": [], "B": []}
+    for v in model.vars:
+        if v.var_type not in ("I", "B"):
+            continue
+        if inv.get(v.idx):
+            continue
+        entry = registry_by_idx.get(v.idx)
+        dangling[v.var_type].append(
+            {
+                "idx": v.idx,
+                "label": label_for_var(v, registry_by_idx),
+                "container": entry[0] if entry else None,
+            }
+        )
+    return dangling
+
+
+# Groepeert een lijst dangling-vermeldingen per containernaam, met een
+# kleine steekproef van labels per groep — een platte lijst van
+# duizenden losse namen (zoals stage_on bij een echte config) is niet
+# leesbaar, een telling per container wel.
+def _group_dangling(entries: list[dict]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {}
+    for e in entries:
+        groups.setdefault(e["container"] or "(unregistered)", []).append(e["label"])
+    return groups
+
+
+# Speelt een snapshot af, zoekt in het opgeloste model naar INTEGER/BINARY-
+# kolommen die in geen enkele constraint voorkomen, en meldt ze gegroepeerd
+# per container. Faalt (exit 1) als er een dangling INTEGER gevonden is —
+# de klasse waarvoor de crash daadwerkelijk bevestigd is (zie
+# _find_dangling_int_columns hierboven); dangling BINARY wordt gemeld maar
+# telt niet mee voor de exitcode, omdat een eigen kleine repro daar geen
+# crash op vond — gerapporteerd, niet genegeerd, alleen niet even hard
+# afgedwongen totdat dat met meer zekerheid is vastgesteld.
+def cmd_dangling(args: argparse.Namespace, data_dir: Path) -> int:
+    if not args.snapshot:
+        raise UsageError("dangling requires --snapshot PATH")
+
+    snapshot_path = _resolve_snapshot_arg(data_dir, args.snapshot)
+    if not snapshot_path.exists():
+        raise UsageError(f"Snapshot not found: {snapshot_path}")
+
+    _ensure_day_ahead_importable()
+    from dao.prog.day_ahead import DaCalc
+
+    guard = _offline_guard() if args.offline else None
+    try:
+        with ReplayIO(snapshot_path, solver_threads=args.threads) as replay:
+            dacalc = DaCalc(str(snapshot_path))
+            dacalc._debug_capture_vars = True
+            dacalc.calc_optimum()
+        model = replay._model
+        registry = getattr(dacalc, "_debug_vars", None)
+    finally:
+        if guard is not None:
+            _offline_unguard(guard)
+
+    if model is None:
+        raise UsageError(
+            "replay never reached model.optimize() — nothing to check "
+            "(check the replay's own log output above for why)"
+        )
+    if not registry:
+        raise UsageError("no variable registry was captured")
+
+    dangling = _find_dangling_int_columns(model, registry.by_idx)
+    integer_count = sum(1 for v in model.vars if v.var_type == "I")
+    binary_count = sum(1 for v in model.vars if v.var_type == "B")
+
+    data = {
+        "snapshot": str(snapshot_path),
+        "integer_count": integer_count,
+        "binary_count": binary_count,
+        "dangling_integer": dangling["I"],
+        "dangling_binary": dangling["B"],
+    }
+
+    # Toont de dangling-kolommen gegroepeerd per container, met een
+    # steekproef van labels per groep.
+    def render(d):
+        print(
+            f"integer variables: {d['integer_count']}  "
+            f"(dangling: {len(d['dangling_integer'])})"
+        )
+        print(
+            f"binary variables:  {d['binary_count']}  "
+            f"(dangling: {len(d['dangling_binary'])})"
+        )
+        for key, kind_label in (("dangling_integer", "INTEGER"), ("dangling_binary", "BINARY")):
+            entries = d[key]
+            if not entries:
+                continue
+            groups = _group_dangling(entries)
+            print(
+                f"dangling {kind_label} columns ({len(entries)} total, "
+                f"{len(groups)} container(s)):"
+            )
+            for container, labels in sorted(groups.items()):
+                sample = ", ".join(labels[:3])
+                more = f", +{len(labels) - 3} more" if len(labels) > 3 else ""
+                print(f"  {container}: {len(labels)}  ({sample}{more})")
+        if not d["dangling_integer"] and not d["dangling_binary"]:
+            print("no dangling integer/binary columns found")
+        if d["dangling_integer"]:
+            print(
+                "WARNING: dangling INTEGER column(s) found — confirmed crash "
+                "trigger on cbcbox 2.935 when combined with an active SOS2 "
+                "curve. Not observed on cbcbox 2.929, the addon's pinned "
+                "version."
+            )
+
+    _emit(args, data, render)
+    return EXIT_ASSERTION_FAILED if data["dangling_integer"] else EXIT_OK
+
+
+# Speelt een snapshot af met _debug_capture_vars aan, zodat day_ahead.py's
+# hook de variabele-registry opbouwt, en dumpt daarna interval --interval:
+# alles wat het opgeloste model erover wist.
 def cmd_dump(args: argparse.Namespace, data_dir: Path) -> int:
     if not args.snapshot:
         raise UsageError("dump requires --snapshot PATH")
@@ -2423,9 +3175,35 @@ def cmd_dump(args: argparse.Namespace, data_dir: Path) -> int:
     if da_prod is not None:
         header["price_prod"] = round(da_prod, 4)
 
-    data = dump_interval(model, registry, args.interval, header=header)
-    _emit(args, data, lambda d: print(_format_dump_text(d)))
+    # Only needed to add a kWh estimate next to each battery's
+    # %-based SoC delta — dacalc.battery_options is set directly from
+    # config in DaBase.__init__ (da_base.py), independent of whether the
+    # solve itself succeeded, so it's available even though the model's
+    # own locals() never expose capacity/one_soc anywhere reachable here.
+    battery_capacity = [
+        float(b.capacity) for b in getattr(dacalc, "battery_options", []) or []
+    ] or None
+
+    data = dump_interval(
+        model, registry, args.interval, header=header, battery_capacity=battery_capacity
+    )
+    _emit(args, data, lambda d: print(_format_dump_text(d, show_all=args.all)))
     return EXIT_OK
+
+
+# Doorzoekt een geneste structuur op een echte -0.0-float (in tegenstelling
+# tot een gewone negatieve waarde als -0.15, die legitiem is). Gebruikt om
+# dump_interval()'s eigen data te controleren op het negative-zero-
+# formatteringsprobleem, in plaats van tekstueel op "-0" te zoeken — dat
+# laatste geeft valse treffers op elke coëfficiënt tussen -1 en 0.
+def _contains_negative_zero(obj) -> bool:
+    if isinstance(obj, float):
+        return obj == 0.0 and math.copysign(1.0, obj) < 0
+    if isinstance(obj, dict):
+        return any(_contains_negative_zero(v) for v in obj.values())
+    if isinstance(obj, (list, tuple)):
+        return any(_contains_negative_zero(v) for v in obj)
+    return False
 
 
 # Interne zelftest voor precies het scenario dat DaBase.get_state raakt: een geërfde, niet-eigen methode moet na restore weer via de klasse-hiërarchie lopen.
@@ -2502,10 +3280,45 @@ def _build_synthetic_sos2_model():
             model += soc[b][u + 1] == soc[b][u] + dc_to_bat[b][u] - dc_from_bat[b][u]
 
     # Force interval 1 idle so a dump of it is a small, quiet contrast to
-    # interval 0's forced full-power charge (mirrors the "idle interval ->
-    # short binding-constraint list" check from the A3 testing section).
+    # interval 0's forced full-power charge.
     model += dc_to_bat[0][1] == 0
     model += dc_from_bat[0][1] == 0
+
+    # dc_from_bat/dc_to_bat are not mutually exclusive in this simplified
+    # model — same known gap as the real formulation — so
+    # maximize(dc_to_bat[0][0]) alone has multiple equally optimal
+    # solutions: AC-side charging (ac_to_dc -> dc_from_ac) and DC-side
+    # "self-discharge into itself" (dc_from_bat) can substitute for each
+    # other freely, since neither costs anything in this bare objective.
+    # Found by an actual regression: CBC's tie-breaking landed on a
+    # different (still optimal) split after an unrelated cbcbox reinstall
+    # mid-session, silently invalidating every hardcoded value in the
+    # selftest below. Pin dc_from_bat[0][0] to 0 so u=0's charge demand
+    # can only be met via the AC/SOS2 path this test actually means to
+    # exercise — assert a direction the model is actually forced into,
+    # not an exact dispatch value that a degenerate model leaves to the
+    # solver's tie-breaking — just applied one level down at
+    # model-construction time instead of in the assertion itself.
+    model += dc_from_bat[0][0] == 0
+
+    # A bare `cost` plus a one-hop chain accumulator
+    # (`cycle_cost`, reusing the real container name so SHAPES/FAMILY
+    # already cover it), exercising both attribution paths dump_interval's
+    # objective block walks — a term directly on cost's own definition,
+    # and one behind a per-battery accumulator's own definition. u=1 is
+    # forced idle above, so cost.x ends up equal to exactly the u=0
+    # attribution's net — a clean invariant to assert against.
+    cost = model.add_var(var_type=CONTINUOUS, lb=-1000, ub=1000)
+    cycle_cost = [model.add_var(var_type=CONTINUOUS, lb=0) for _ in range(B)]
+    for b in range(B):
+        model += cycle_cost[b] == xsum(
+            (dc_to_bat[b][u] + dc_from_bat[b][u]) * 0.01 for u in range(U)
+        )
+    model += cost == (
+        xsum(dc_to_bat[0][u] * 0.2 - dc_from_bat[0][u] * 0.15 for u in range(U))
+        + cycle_cost[0]
+    )
+
     model.objective = maximize(dc_to_bat[0][0])
     model.verbose = 0
     model.optimize()
@@ -2586,8 +3399,8 @@ def cmd_selftest(args: argparse.Namespace, data_dir: Path) -> int:
             raise AssertionError(f"unexpected registry size {len(registry)}")
 
     # Controleert dat de volledigheidscontrole afgaat op een containernaam
-    # die niet in SHAPES/SHAPES_IGNORE staat (A3 Testing: "add a container
-    # without updating SHAPES").
+    # die niet in SHAPES/SHAPES_IGNORE staat — het "voeg een container toe
+    # zonder SHAPES bij te werken"-scenario.
     def _shapes_completeness_fires_on_unknown_container():
         bad_registry = {0: ("mystery_container_nobody_declared", (0,))}
         try:
@@ -2600,46 +3413,202 @@ def cmd_selftest(args: argparse.Namespace, data_dir: Path) -> int:
 
     # End-to-end: los het synthetische SOS2-model op en controleer dat
     # dump_interval op de dwangmatig ladende interval de juiste vermogens,
-    # soc-in/out, en een aangrenzende actieve SOS2-trap teruggeeft, en dat
-    # de gerenderde binding constraints geen "var(N)"-fallback bevatten
-    # (d.w.z. dat elke variabele daadwerkelijk een registry-label kreeg).
+    # soc-in/out (nu als één boundary-rij met delta), een aangrenzende
+    # actieve SOS2-trap, en de objective-attributie teruggeeft, en dat de
+    # gerenderde constraints geen "var(N)"-fallback bevatten (d.w.z. dat
+    # elke variabele daadwerkelijk een registry-label kreeg).
     def _dump_interval_charging_interval():
         if mip is None:
             return
         model, registry = _build_synthetic_sos2_model()
         data = dump_interval(model, registry, 0, header={"dao_version": "selftest"})
-        by_label = {e["label"]: e["value"] for e in data["sections"]["battery 0"]}
-        if abs(by_label["ac_to_dc[0][0]"] - 5.0) > 1e-6:
+        rows = data["sections"]["battery 0"]
+        scalars = {r["label"]: r["value"] for r in rows if r["kind"] == "scalar"}
+        boundaries = {r["label"]: r for r in rows if r["kind"] == "boundary"}
+        if abs(scalars["ac_to_dc[b=0][u=0]"] - 5.0) > 1e-6:
             raise AssertionError("charging interval did not reach full charge power")
-        if abs(by_label["soc[0][0]"] - 50.0) > 1e-6 or abs(by_label["soc[0][1]"] - 54.5) > 1e-6:
+        soc_row = boundaries["soc[b=0]"]
+        if abs(soc_row["value_in"] - 50.0) > 1e-6 or abs(soc_row["value_out"] - 54.5) > 1e-6:
             raise AssertionError("soc in/out did not match the forced charge")
+        if abs(soc_row["delta"] - 4.5) > 1e-6:
+            raise AssertionError("soc delta did not match value_out - value_in")
         charge_curve = next(r for r in data["sos2"] if r["curve"] == "battery charge")
-        if not charge_curve["adjacent"] or not charge_curve["active_stages"]:
-            raise AssertionError("SOS2 charge curve should report one adjacent active stage")
-        if abs(charge_curve["interpolated"] - by_label["ac_to_dc[0][0]"]) > 1e-6:
-            raise AssertionError("SOS2 interpolated power should equal ac_to_dc[0][0]")
-        if not data["binding_constraints"]:
+        if not charge_curve["adjacent"] or charge_curve["case"] != "single":
+            raise AssertionError("SOS2 charge curve should report a single adjacent active stage")
+        if abs(charge_curve["interpolated"] - scalars["ac_to_dc[b=0][u=0]"]) > 1e-6:
+            raise AssertionError("SOS2 interpolated power should equal ac_to_dc[b=0][u=0]")
+        if not data["local_constraints"] and not data["global_constraints"]:
             raise AssertionError("a forced-charge interval should have binding constraints")
-        if any("var(" in bc["text"] for bc in data["binding_constraints"]):
-            raise AssertionError("a binding constraint fell back to var(N) — a registered var wasn't labelled")
-        if "-0" in _format_dump_text(data):
-            raise AssertionError("rendered output contains a stray -0 (negative-zero formatting bug)")
+        all_text = " ".join(lc["text"] for lc in data["local_constraints"])
+        if "var(" in all_text:
+            raise AssertionError("a local constraint fell back to var(N) — a registered var wasn't labelled")
+        if _contains_negative_zero(data):
+            raise AssertionError("dump_interval() returned a -0.0 float (negative-zero formatting bug)")
+        # objective attribution: net at u=0 must equal cost.x,
+        # since u=1 is forced fully idle in the synthetic model — see
+        # _build_synthetic_sos2_model's comment.
+        cost_idx = _find_scalar_idx(registry.by_idx, "cost")
+        if cost_idx is None:
+            raise AssertionError("cost was not registered as a bare scalar var")
+        cost_value = model.vars[cost_idx].x
+        if not data["objective_contributions"]:
+            raise AssertionError("expected at least one objective contribution at u=0")
+        if abs(data["objective_net"] - cost_value) > 1e-6:
+            raise AssertionError(
+                f"objective net {data['objective_net']} != cost.x {cost_value} "
+                f"(u=1 is forced idle, so they should match exactly)"
+            )
+        # the chain term (cycle_cost -> dc_to_bat/dc_from_bat) must appear
+        # alongside the direct term, proving the one-hop walk fired.
+        contrib_labels = {c["label"] for c in data["objective_contributions"]}
+        if "dc_to_bat[b=0][u=0]" not in contrib_labels:
+            raise AssertionError("expected dc_to_bat[b=0][u=0] in the objective attribution")
 
     # Idle interval (dwongen tot 0 laden/ontladen): moet nog steeds netjes
-    # dumpen zonder te crashen, en zonder een van de over-matching
-    # symptomen (een lege binding-constraint-lijst zou juist verdacht zijn
-    # geweest — hier moet de energie-balans/soc-koppeling nog steeds
-    # binding zijn).
+    # dumpen zonder te crashen. Met onderdrukking aan moet de uitvoer korter
+    # zijn dan met --all.
     def _dump_interval_idle_interval():
         if mip is None:
             return
         model, registry = _build_synthetic_sos2_model()
         data = dump_interval(model, registry, 1)
-        by_label = {e["label"]: e["value"] for e in data["sections"]["battery 0"]}
-        if abs(by_label["ac_to_dc[0][1]"]) > 1e-6 or abs(by_label["ac_from_dc[0][1]"]) > 1e-6:
+        rows = data["sections"]["battery 0"]
+        scalars = {r["label"]: r["value"] for r in rows if r["kind"] == "scalar"}
+        if abs(scalars["ac_to_dc[b=0][u=1]"]) > 1e-6 or abs(scalars["ac_from_dc[b=0][u=1]"]) > 1e-6:
             raise AssertionError("forced-idle interval should show zero flow")
         if not data["context"].get("0"):
             raise AssertionError("interval 1 should carry reduced context for its u=0 neighbour")
+        suppressed = _format_dump_text(data, show_all=False)
+        full = _format_dump_text(data, show_all=True)
+        if len(suppressed.splitlines()) >= len(full.splitlines()):
+            raise AssertionError("--all should show fewer or equal lines suppressed than with --all")
+        # a known-zero row (forced idle) must vanish under suppression but
+        # still appear with --all — the actual suppression behaviour, not
+        # just "fewer lines" in the abstract. Matched against the exact
+        # section-row format (not a bare label substring): that same label
+        # legitimately still appears in constraint text either way, so a
+        # plain "in" check on the whole text would never fail.
+        zero_row = f"    {'ac_from_dc[b=0][u=1]':<28} {0.0:.4f} kW"
+        if zero_row in suppressed:
+            raise AssertionError("a zero-valued row should be suppressed by default")
+        if zero_row not in full:
+            raise AssertionError("--all should still show zero-valued rows")
+
+    # cost/delivery/production must render by name, not var(NNNNN) — bare
+    # Vars in locals() must be picked up by build_var_registry, not just
+    # Vars inside a list/tuple.
+    def _scalar_vars_labelled_by_name():
+        if mip is None:
+            return
+        from mip import Model, CONTINUOUS
+
+        model = Model()
+        cost = model.add_var(var_type=CONTINUOUS, lb=-1000, ub=1000)
+        delivery = model.add_var(var_type=CONTINUOUS, lb=0, ub=1000)
+        production = model.add_var(var_type=CONTINUOUS, lb=0, ub=1000)
+        model += cost == delivery - production
+        registry = build_var_registry(locals())
+        by_name = {n: idx for idx, (n, path) in registry.by_idx.items() if path == ()}
+        for name, var in (("cost", cost), ("delivery", delivery), ("production", production)):
+            if by_name.get(name) != var.idx:
+                raise AssertionError(f"{name} was not registered as a bare scalar var")
+            label = label_for_var(var, registry.by_idx)
+            if label != name:
+                raise AssertionError(f"expected label {name!r}, got {label!r}")
+
+    # A 121-interval run of identical-coefficient terms from one
+    # container collapses to a single Σ line; three non-contiguous
+    # intervals do not collapse.
+    def _sigma_collapse_contiguity():
+        if mip is None:
+            return
+        from mip import Model, BINARY, xsum
+
+        model = Model()
+        U = 121
+        boiler_on = [model.add_var(var_type=BINARY) for _ in range(U)]
+        c_contig = model.add_constr(xsum(boiler_on[u] for u in range(U)) == 0)
+        registry_by_idx = build_var_registry(locals()).by_idx
+        sigma = _try_sigma_collapse(c_contig, registry_by_idx)
+        if sigma is None or "0..120" not in sigma:
+            raise AssertionError(f"expected a full-horizon Σ collapse, got {sigma!r}")
+
+        model2 = Model()
+        boiler_on2 = [model2.add_var(var_type=BINARY) for _ in range(U)]
+        c_sparse = model2.add_constr(
+            boiler_on2[0] + boiler_on2[50] + boiler_on2[100] == 0
+        )
+        registry_by_idx2 = build_var_registry(locals()).by_idx
+        sigma2 = _try_sigma_collapse(c_sparse, registry_by_idx2)
+        if sigma2 is not None:
+            raise AssertionError(f"three non-contiguous intervals should not collapse, got {sigma2!r}")
+
+    # Every named pattern matches a constraint with exactly its
+    # signature; an unmatched signature falls back to None without
+    # raising.
+    def _pattern_labeller_coverage():
+        if mip is None:
+            return
+        for signature, expected_label in _CONSTRAINT_PATTERNS.items():
+            model = mip.Model()
+            fake_registry: dict = {}
+            terms = []
+            for i, name in enumerate(sorted(signature)):
+                v = model.add_var(var_type=mip.CONTINUOUS)
+                fake_registry[v.idx] = (name, (0,))
+                terms.append(v)
+            c = model.add_constr(mip.xsum(terms) == 0)
+            got = _match_pattern(c, fake_registry)
+            if got != expected_label:
+                raise AssertionError(
+                    f"pattern {sorted(signature)} expected {expected_label!r}, got {got!r}"
+                )
+        # unmatched signature: falls back to None, does not raise
+        model = mip.Model()
+        v = model.add_var(var_type=mip.CONTINUOUS)
+        c = model.add_constr(v == 0)
+        got = _match_pattern(c, {v.idx: ("totally_unmatched_container", (0,))})
+        if got is not None:
+            raise AssertionError(f"expected no pattern match, got {got!r}")
+
+    # A SHAPES entry with dims but an empty unit must fail
+    # the completeness check exactly like a missing container would.
+    def _shapes_completeness_requires_unit():
+        original = SHAPES.get("soc")
+        SHAPES["soc"] = (original[0], "", original[2])
+        try:
+            _assert_shapes_complete({0: ("soc", (0, 0))})
+        except VarRegistryError:
+            pass
+        else:
+            raise AssertionError("completeness assertion did not fire on a unit-less SHAPES entry")
+        finally:
+            SHAPES["soc"] = original
+
+    # Bouwt een model met één ongebruikte (dangling) INTEGER-variabele naast
+    # een wél-gebruikte INTEGER en BINARY, en controleert dat
+    # _find_dangling_int_columns precies de ongebruikte vindt — geen
+    # gemiste treffer, geen vals-positief op de gebruikte variabelen.
+    def _dangling_int_column_detection():
+        if mip is None:
+            return
+        from mip import Model, CONTINUOUS, INTEGER, BINARY
+
+        model = Model()
+        used_int = model.add_var(var_type=INTEGER, lb=0, ub=5)
+        dangling_int = model.add_var(var_type=INTEGER, lb=0, ub=5)
+        used_bin = model.add_var(var_type=BINARY)
+        c = model.add_var(var_type=CONTINUOUS)
+        model += c == used_int + used_bin
+        registry = build_var_registry(locals())
+        dangling = _find_dangling_int_columns(model, registry.by_idx)
+        dangling_int_labels = {e["label"] for e in dangling["I"]}
+        if "dangling_int" not in dangling_int_labels:
+            raise AssertionError("failed to detect a genuinely dangling INTEGER var")
+        if "used_int" in dangling_int_labels:
+            raise AssertionError("false positive: used_int is referenced in a constraint")
+        if any(e["label"] == "used_bin" for e in dangling["B"]):
+            raise AssertionError("false positive: used_bin is referenced in a constraint")
 
     for name, fn in [
         ("dataframe_roundtrip", _dataframe_roundtrip),
@@ -2649,6 +3618,11 @@ def cmd_selftest(args: argparse.Namespace, data_dir: Path) -> int:
         ("patch_list_restore", _patch_list_restore_check),
         ("var_registry_nested_containers", _var_registry_nested_containers),
         ("shapes_completeness_fires_on_unknown_container", _shapes_completeness_fires_on_unknown_container),
+        ("shapes_completeness_requires_unit", _shapes_completeness_requires_unit),
+        ("scalar_vars_labelled_by_name", _scalar_vars_labelled_by_name),
+        ("sigma_collapse_contiguity", _sigma_collapse_contiguity),
+        ("pattern_labeller_coverage", _pattern_labeller_coverage),
+        ("dangling_int_column_detection", _dangling_int_column_detection),
         ("dump_interval_charging_interval", _dump_interval_charging_interval),
         ("dump_interval_idle_interval", _dump_interval_idle_interval),
     ]:
@@ -2728,8 +3702,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Same idea as day_ahead.py's own debug mode "
         "(calc_optimum_met_debug): sets self.debug = True before solving, "
         "which gates most writes, plus suppresses the few that aren't "
-        "gated by that flag (self.notify(), one set_value() call — "
-        "architecture doc §1.2). All reads still happen for real and are "
+        "gated by that flag (self.notify(), one set_value() call in "
+        "day_ahead.py). All reads still happen for real and are "
         "still captured. Use this while iterating so repeated captures "
         "don't keep pushing real settings to HA/DB. Unrelated to --png "
         "(see below) — that's controlled separately.",
@@ -2812,6 +3786,30 @@ def build_arg_parser() -> argparse.ArgumentParser:
         metavar="N",
         help="CBC thread count for the replay dump reads from (same semantics as `replay --threads`). Default -1.",
     )
+    p.add_argument(
+        "--all",
+        action="store_true",
+        default=False,
+        help="Show every variable, including exact zeros. Off by "
+        "default: zero values are suppressed and a fully-zero asset group "
+        "collapses to one 'idle' line.",
+    )
+
+    p = sub.add_parser(
+        "dangling",
+        parents=[common],
+        help="Replay a snapshot and report INTEGER/BINARY columns used in no constraint (a known CBC crash trigger on some solver builds when combined with an active SOS2 curve).",
+    )
+    p.add_argument("--snapshot", default=None, required=True)
+    p.add_argument("--offline", dest="offline", action="store_true", default=True, help="Block all network access during the replay this needs (default).")
+    p.add_argument("--allow-network", dest="offline", action="store_false", help="Disable the network block (escape hatch).")
+    p.add_argument(
+        "--threads",
+        type=int,
+        default=-1,
+        metavar="N",
+        help="CBC thread count for the replay this reads from (same semantics as `replay --threads`). Default -1.",
+    )
 
     sub.add_parser("selftest", parents=[common], help="Run da_debug's own offline checks.")
 
@@ -2826,6 +3824,7 @@ _COMMANDS = {
     "diff": cmd_diff,
     "set": cmd_set,
     "dump": cmd_dump,
+    "dangling": cmd_dangling,
     "selftest": cmd_selftest,
 }
 

--- a/dao/prog/da_debug.py
+++ b/dao/prog/da_debug.py
@@ -2003,14 +2003,20 @@ def cmd_replay(args: argparse.Namespace, data_dir: Path) -> int:
     from dao.prog.day_ahead import DaCalc
 
     guard = _offline_guard() if args.offline else None
-    result = None
     try:
         with ReplayIO(snapshot_path, solver_threads=args.threads, png=args.png) as replay:
             file_name = str(snapshot_path)
             dacalc = DaCalc(file_name)
-            result = dacalc.calc_optimum()
+            # calc_optimum()'s return value is not a usable success signal —
+            # see the matching comment in cmd_dump: it returns None
+            # unconditionally, on success and on every failure path alike.
+            # The solved model's own num_solutions, captured by ReplayIO's
+            # mip.Model.optimize() wrapper, is what actually tells success
+            # from failure below.
+            dacalc.calc_optimum()
         reads = sorted(replay.reads)
         result_dict = replay.build_result()
+        solved = replay._model is not None and replay._model.num_solutions > 0
     finally:
         if guard is not None:
             _offline_unguard(guard)
@@ -2046,7 +2052,7 @@ def cmd_replay(args: argparse.Namespace, data_dir: Path) -> int:
         print(f"result:   {d['result']}" if d["result"] else "result:   not written (solve never reached model.optimize())")
 
     _emit(args, data, render)
-    return EXIT_OK if result is not None else EXIT_SOLVER_FAILURE
+    return EXIT_OK if solved else EXIT_SOLVER_FAILURE
 
 
 # Toont een samenvatting van een snapshot en eventueel resultaat, zonder de solver te draaien.
@@ -2364,7 +2370,14 @@ def cmd_dump(args: argparse.Namespace, data_dir: Path) -> int:
         with ReplayIO(snapshot_path, solver_threads=args.threads) as replay:
             dacalc = DaCalc(str(snapshot_path))
             dacalc._debug_capture_vars = True
-            result = dacalc.calc_optimum()
+            # calc_optimum() always returns None — on success and on every
+            # failure path alike (day_ahead.py's own final line is an
+            # unconditional `return None`; it communicates outcome via
+            # self/notify/logging, not a return value). So the return value
+            # here is not a usable success signal; the solved model's own
+            # num_solutions/status, captured separately below via
+            # ReplayIO's mip.Model.optimize() wrapper, is.
+            dacalc.calc_optimum()
         model = replay._model
         registry = getattr(dacalc, "_debug_vars", None)
         meta = replay.meta
@@ -2372,10 +2385,15 @@ def cmd_dump(args: argparse.Namespace, data_dir: Path) -> int:
         if guard is not None:
             _offline_unguard(guard)
 
-    if model is None or result is None:
+    if model is None:
         raise UsageError(
-            "replay never reached a solved model.optimize() — nothing to "
-            "dump (see any error logged above)"
+            "replay never reached model.optimize() — nothing to dump "
+            "(check the replay's own log output above for why)"
+        )
+    if getattr(model, "num_solutions", 0) == 0:
+        raise UsageError(
+            f"replay's model has no solution (status="
+            f"{getattr(model.status, 'name', model.status)}) — nothing to dump"
         )
     if not registry:
         raise UsageError(

--- a/dao/prog/da_debug.py
+++ b/dao/prog/da_debug.py
@@ -27,9 +27,12 @@ Both classes are context managers that must be entered *before* any
 of the channels they patch (config, strategy resolution, the HA REST call in
 the constructor) are read inside ``DaBase.__init__`` itself.
 
-Only the input cut-set (§2.1) and the snapshot format (§2.2) are implemented
-here. The variable registry and ``dump_interval`` (§2.3-§2.5) are a
-separate, later piece of work; ``RecordingIO`` does not depend on them.
+The input cut-set (§2.1), the snapshot format (§2.2), the variable registry
+(§2.3) and ``dump_interval`` (§2.5) are all implemented here. ``RecordingIO``
+and ``ReplayIO`` do not depend on the registry or ``dump_interval`` — those
+are only wired together by the ``dump`` CLI command, which replays a
+snapshot to get a solved model plus its registry and then prints what the
+solver knew about one interval.
 """
 
 from __future__ import annotations
@@ -463,9 +466,11 @@ def _build_result_dict(model, cbc_log_chunks: list[str], extra_meta: dict) -> Op
             "cbc_log": "\n".join(cbc_log_chunks) if cbc_log_chunks else None,
             "note": (
                 "Per-interval dispatch and SoC trajectory are not captured "
-                "yet — they need the variable registry (architecture doc "
-                "§2.3/§2.5), which is separate follow-up work, not part of "
-                "this snapshot format."
+                "in this result file — objective/status/gap only. Use the "
+                "`dump` CLI command (architecture doc §2.5) against the "
+                "snapshot to see what a solved model knew about a specific "
+                "interval; that needs a live re-solve via ReplayIO and "
+                "isn't something a static result file can hold."
             ),
         }
     except Exception:
@@ -1158,6 +1163,559 @@ class ReplayIO:
 
 
 # ---------------------------------------------------------------------------
+# Variable registry (A1's hook 1, §2.3) and dump_interval (A3, §2.5)
+# ---------------------------------------------------------------------------
+#
+# day_ahead.py's calc_optimum() already calls build_var_registry(locals())
+# just before model.optimize() when self._debug_capture_vars is set (the
+# hook A1 landed). Nothing here is reachable from an ordinary run: the flag
+# defaults to unset, and everything below is only ever driven by the `dump`
+# CLI command or by tests that build a synthetic mip.Model directly.
+
+
+class VarRegistryError(RuntimeError):
+    """Raised when the registry contains a container with no SHAPES entry
+    and no SHAPES_IGNORE entry — i.e. calc_optimum() grew a new variable
+    family that dump_interval was never taught the axis layout of. This is
+    meant to fail loudly (§2.5's "completeness assertion") rather than
+    silently omit the new container from every future dump."""
+
+
+# Bouwt {var.idx: (containernaam, indextuple)} uit calc_optimum()'s eigen
+# locals() vlak vóór model.optimize(); loopt alleen door lists/tuples, dus
+# DataFrames, configobjecten en losse scalars worden vanzelf overgeslagen.
+def build_var_registry(local_vars: dict) -> dict[int, tuple[str, tuple]]:
+    """§2.3: ``{var.idx: (container_name, index_tuple)}`` built from
+    ``calc_optimum()``'s own ``locals()`` just before ``model.optimize()``.
+
+    Only walks values that are themselves ``list``/``tuple`` at the top
+    level, then recurses through nested lists/tuples looking for ``mip.Var``
+    leaves. This is deliberate, not incidental: mip never names variables
+    (0 of 81 ``add_var`` call sites in day_ahead.py pass ``name=``, per the
+    architecture doc's §0.7 finding 1), so there is nothing to key on but
+    the Python container structure — and restricting the walk to
+    list/tuple means DataFrames, pydantic config objects, and plain scalar
+    locals are dead ends rather than needing an exclude list. Keyed by
+    ``var.idx`` rather than the ``Var`` object itself, because
+    ``mip.Var.__eq__`` returns a ``LinExpr`` rather than a bool and
+    ``var.idx`` is unique per model regardless (architecture doc §2.3).
+    """
+    registry: dict[int, tuple[str, tuple]] = {}
+    if mip is None:
+        return registry
+
+    # Loopt recursief door een (geneste) list/tuple en registreert elke
+    # Var-leaf onder zijn containernaam en indexpad.
+    def _walk(name: str, value, path: tuple) -> None:
+        if isinstance(value, mip.Var):
+            registry[value.idx] = (name, path)
+        elif isinstance(value, (list, tuple)):
+            for i, item in enumerate(value):
+                _walk(name, item, path + (i,))
+        # Everything else (DataFrame, dict, pydantic model, float, str,
+        # None, ...) is neither a Var nor a container to recurse into.
+
+    for name, value in local_vars.items():
+        if isinstance(value, (list, tuple)):
+            _walk(name, value, ())
+    return registry
+
+
+# Declaratieve as-indeling per containernaam: welke Python-loopvariabele
+# hoort bij welke positie in de geneste lijst. "u" is het interval-as,
+# "u_boundary" is dezelfde as maar met lengte U+1 (SoC-grenzen). Geschreven
+# tegen de huidige day_ahead.py door de model-bouwsectie te lezen, niet
+# afgeleid uit de namen — zie de architectuurdoc §2.5 voor het voorbeeld dat
+# dit uitbreidt.
+SHAPES: dict[str, tuple[str, ...]] = {
+    # solar (top-level AC-coupled arrays, independent of any battery)
+    "pv_ac": ("s", "u"),
+    "pv_ac_on_off": ("s", "u"),
+    # battery — DC-coupled solar feeding this battery specifically
+    "pv_dc_on_off": ("b", "pvdc", "u"),
+    "pv_prod_dc_sum": ("b", "u"),
+    # battery — AC<->DC, both curves are SOS2 (§2.5); the commented
+    # on/off-without-SOS alternatives never execute, so they never appear
+    # in locals() and need no entry here
+    "ac_to_dc": ("b", "u"),
+    "ac_to_dc_on": ("b", "u"),
+    "ac_to_dc_w": ("b", "u", "cs"),  # SOS2 weight, charge
+    "ac_from_dc": ("b", "u"),
+    "ac_from_dc_on": ("b", "u"),
+    "ac_from_dc_w": ("b", "u", "ds"),  # SOS2 weight, discharge
+    "dc_from_ac": ("b", "u"),
+    "dc_to_ac": ("b", "u"),
+    "dc_from_bat": ("b", "u"),
+    "dc_to_bat": ("b", "u"),
+    "soc": ("b", "u_boundary"),
+    "soc_low": ("b", "u_boundary"),
+    "soc_mid": ("b", "u_boundary"),
+    "cycle_cost": ("b",),
+    "penalty_cost": ("b",),
+    # boiler (single, not indexed by asset)
+    "boiler_on": ("u",),
+    "boiler_st": ("u",),
+    "boiler_temp": ("u_boundary",),
+    "c_b": ("u",),
+    # ev — note stage_* is [e][ecs][u] (stage before interval), while every
+    # other per-ev container is [e][u]; a transposed index here would
+    # produce plausible-looking wrong numbers (architecture doc §8.5)
+    "stage_consumption": ("e", "ecs", "u"),
+    "stage_factor": ("e", "ecs", "u"),
+    "stage_on": ("e", "ecs", "u"),
+    "c_ev": ("e", "u"),
+    "p_ev": ("e", "u"),
+    "ev_accu_in": ("e", "u"),
+    "ev_soc_kwh": ("e", "u"),
+    "ev_is_on": ("e", "u"),
+    "ev_is_off": ("e", "u"),
+    "ev_is_partial": ("e", "u"),
+    "ev_boundary_stop": ("e", "u"),
+    "ev_partial_sum": ("e",),
+    "ev_boundary_sum": ("e",),
+    "ev_start_stops_sum": ("e",),
+    "ev_delta_soc": ("e", "u"),
+    "low_soc_penalty_int": ("e", "u"),
+    "low_soc_penalty": ("e",),
+    "switch_cost": ("e",),
+    # grid
+    "c_l": ("u",),
+    "c_t": ("u",),
+    "c_l_on": ("u",),
+    "c_t_on": ("u",),
+    # heat pump — mutually exclusive per run depending on
+    # heating_options.adjustment: "on/off" builds hp_bl_on/hp_start_index,
+    # "power"/"heating curve" builds p_hp/hp_s_w (third active add_sos() —
+    # architecture doc §11, A0 Q7). Note p_hp is [s][u] while its own
+    # SOS2 weight hp_s_w is [u][s] — transposed relative to each other,
+    # same class of trap as the EV stage arrays above.
+    "c_hp": ("u",),
+    "hp_on": ("u",),
+    "h_hp": ("u",),
+    "hp_bl_on": ("blk", "u"),
+    "hp_start_index": ("blk",),
+    "p_hp": ("s_hp", "u"),
+    "hp_s_w": ("u", "s_hp"),  # SOS2 weight, heat pump
+    # machines
+    "ma_start": ("m", "kw"),
+    "c_ma_kw": ("m", "kw"),
+    "c_ma_u": ("m", "u"),
+}
+
+# Containers that legitimately produce Var leaves but are deliberately not
+# part of a per-interval dump (currently none — every container that shows
+# up in the registry has a SHAPES entry above). Kept as a real set, not a
+# comment, so _assert_shapes_complete has somewhere to point a genuinely
+# non-interval container without that container silently vanishing from
+# every dump.
+SHAPES_IGNORE: frozenset[str] = frozenset()
+
+# Grouping used only for dump_interval's human-readable output — which
+# heading a container's values print under. Purely cosmetic: an unlisted
+# container still passes _assert_shapes_complete as long as it's in SHAPES,
+# it just prints under "other".
+FAMILY: dict[str, str] = {
+    "pv_ac": "solar",
+    "pv_ac_on_off": "solar",
+    "pv_dc_on_off": "battery",
+    "pv_prod_dc_sum": "battery",
+    "ac_to_dc": "battery",
+    "ac_to_dc_on": "battery",
+    "ac_to_dc_w": "battery",
+    "ac_from_dc": "battery",
+    "ac_from_dc_on": "battery",
+    "ac_from_dc_w": "battery",
+    "dc_from_ac": "battery",
+    "dc_to_ac": "battery",
+    "dc_from_bat": "battery",
+    "dc_to_bat": "battery",
+    "soc": "battery",
+    "soc_low": "battery",
+    "soc_mid": "battery",
+    "cycle_cost": "battery",
+    "penalty_cost": "battery",
+    "boiler_on": "boiler",
+    "boiler_st": "boiler",
+    "boiler_temp": "boiler",
+    "c_b": "boiler",
+    "stage_consumption": "ev",
+    "stage_factor": "ev",
+    "stage_on": "ev",
+    "c_ev": "ev",
+    "p_ev": "ev",
+    "ev_accu_in": "ev",
+    "ev_soc_kwh": "ev",
+    "ev_is_on": "ev",
+    "ev_is_off": "ev",
+    "ev_is_partial": "ev",
+    "ev_boundary_stop": "ev",
+    "ev_partial_sum": "ev",
+    "ev_boundary_sum": "ev",
+    "ev_start_stops_sum": "ev",
+    "ev_delta_soc": "ev",
+    "low_soc_penalty_int": "ev",
+    "low_soc_penalty": "ev",
+    "switch_cost": "ev",
+    "c_l": "grid",
+    "c_t": "grid",
+    "c_l_on": "grid",
+    "c_t_on": "grid",
+    "c_hp": "heatpump",
+    "hp_on": "heatpump",
+    "h_hp": "heatpump",
+    "hp_bl_on": "heatpump",
+    "hp_start_index": "heatpump",
+    "p_hp": "heatpump",
+    "hp_s_w": "heatpump",
+    "ma_start": "machine",
+    "c_ma_kw": "machine",
+    "c_ma_u": "machine",
+}
+
+# Asset-index axes that get their own sub-heading in the text render
+# ("battery 0", "ev 1", ...) when they are a container's leading axis.
+_ASSET_AXES = ("b", "e", "m")
+
+
+# Faalt hard, met de namen van de onbekende containers, zodra de registry
+# een containernaam bevat die niet in SHAPES of SHAPES_IGNORE voorkomt —
+# dit is de "voeg een container toe zonder SHAPES bij te werken" val uit de
+# A3-testparagraaf.
+def _assert_shapes_complete(registry: dict) -> None:
+    names = {name for name, _ in registry.values()}
+    unknown = sorted(names - set(SHAPES) - SHAPES_IGNORE)
+    if unknown:
+        raise VarRegistryError(
+            f"{len(unknown)} variable container(s) have no SHAPES entry "
+            f"and are not on SHAPES_IGNORE: {', '.join(unknown)}. "
+            f"calc_optimum() grew a new variable family; add its axis "
+            f"layout to SHAPES (or to SHAPES_IGNORE if it's deliberately "
+            f"not interval-addressable) in da_debug.py before dump can "
+            f"cover it."
+        )
+
+
+# Groepeert de registry per containernaam, nodig omdat build_var_registry
+# zelf per var.idx sleutelt en dump_interval juist per container wil kunnen
+# selecteren.
+def _group_by_container(registry: dict) -> dict[str, list[tuple[tuple, int]]]:
+    groups: dict[str, list[tuple[tuple, int]]] = {}
+    for var_idx, (name, idx_tuple) in registry.items():
+        groups.setdefault(name, []).append((idx_tuple, var_idx))
+    return groups
+
+
+# Zoekt de interval-as van een SHAPES-vorm op: positie plus of het de
+# U+1-grensvariant (soc-achtig) is. Geeft None als de container geen
+# interval-as heeft (bv. cycle_cost, alleen per batterij).
+def _interval_axis(shape: tuple[str, ...]) -> Optional[tuple[int, bool]]:
+    if "u_boundary" in shape:
+        return shape.index("u_boundary"), True
+    if "u" in shape:
+        return shape.index("u"), False
+    return None
+
+
+# Selecteert uit een containers items alleen de indextuples waarvan de
+# interval-as in `wanted` zit; geeft (indextuple, var_idx)-paren terug.
+def _select_at(entries: list[tuple[tuple, int]], axis_pos: int, wanted: set[int]):
+    return [(idx, vidx) for idx, vidx in entries if idx[axis_pos] in wanted]
+
+
+# Bouwt eenmalig var.idx -> [constraint-index, ...] en cachet dat op het
+# model, zodat meerdere dump_interval-aanroepen tegen hetzelfde opgeloste
+# model de O(aantal constraints)-kost maar één keer betalen (§2.5, gemeten
+# 10ms bij 2304 constraints).
+def _inverse_var_constraint_index(model) -> dict[int, list[int]]:
+    cached = getattr(model, "_debug_inv_index", None)
+    if cached is not None:
+        return cached
+    inv: dict[int, list[int]] = {}
+    for ci, c in enumerate(model.constrs):
+        for v in c.expr.expr:
+            inv.setdefault(v.idx, []).append(ci)
+    try:
+        model._debug_inv_index = inv
+    except Exception:  # pragma: no cover - mip.Model has no __slots__ today
+        pass
+    return inv
+
+
+# Berekent (activity, rhs) van een constraint rechtstreeks uit coëfficiënten
+# en opgeloste waarden, in plaats van op het teken van c.slack te vertrouwen
+# — c.expr.const is de negatieve RHS [geverifieerd tegen een echt mip-model].
+def _constraint_activity(c) -> tuple[float, float]:
+    activity = sum(coef * v.x for v, coef in c.expr.expr.items())
+    rhs = -c.expr.const
+    return activity, rhs
+
+
+# Een constraint is bindend als de activity binnen tolerantie gelijk is aan
+# de rhs.
+def _is_binding(c, tol: float = 1e-6) -> bool:
+    activity, rhs = _constraint_activity(c)
+    return abs(activity - rhs) < tol
+
+
+# Vertaalt een Var naar zijn leesbare label via de registry, of naar
+# var(idx) als de Var niet geregistreerd is (bv. de kale cost/delivery-
+# variabelen, die nooit in een list/tuple zaten en dus geen registry-entry
+# hebben — build_var_registry loopt bewust alleen door containers).
+def label_for_var(var, registry: dict) -> str:
+    entry = registry.get(var.idx)
+    if entry is None:
+        return f"var({var.idx})"
+    name, idx = entry
+    return name + "".join(f"[{i}]" for i in idx)
+
+
+_SENSE_SYMBOLS = {"<": "<=", ">": ">=", "=": "="}
+
+
+# Rendert een constraint met registry-labels in plaats van var(N)/constr(N),
+# bv. "ac_to_dc[0][14] - 0.95*dc_from_ac[0][14] = 0".
+def render_constraint(c, registry: dict) -> str:
+    terms = sorted(
+        ((coef, label_for_var(v, registry)) for v, coef in c.expr.expr.items()),
+        key=lambda t: t[1],
+    )
+    pieces: list[str] = []
+    for coef, label in terms:
+        magnitude = abs(coef)
+        coef_str = "" if abs(magnitude - 1) < 1e-12 else f"{magnitude:g}*"
+        term = f"{coef_str}{label}"
+        if not pieces:
+            pieces.append(f"-{term}" if coef < 0 else term)
+        else:
+            pieces.append(f"- {term}" if coef < 0 else f"+ {term}")
+    lhs = " ".join(pieces) if pieces else "0"
+    rhs = -c.expr.const + 0.0  # normalises -0.0 to 0.0 so it doesn't print as "-0"
+    sense = _SENSE_SYMBOLS.get(c.expr.sense, c.expr.sense)
+    return f"{lhs} {sense} {rhs:g}"
+
+
+# Elke actieve SOS2-curve in het model: (label, gewichtscontainer, as-naam
+# van de trap, container met de al-geïnterpoleerde waarde). python-mip
+# biedt geen manier om SOS-sets na add_sos() terug op te vragen, dus dit kan
+# alleen uit de gewichtsvariabelen zelf komen, niet uit constraint-inspectie
+# (§2.5). Drie sites, zie A0 Q7 / architectuurdoc §11: batterij laden,
+# batterij ontladen, warmtepomp (alleen aanwezig bij adjustment "power" /
+# "heating curve" — de "on/off"-tak gebruikt hp_bl_on zonder SOS2).
+_SOS2_CURVES = (
+    ("battery charge", "ac_to_dc_w", "cs", "ac_to_dc"),
+    ("battery discharge", "ac_from_dc_w", "ds", "ac_from_dc"),
+    ("heat pump", "hp_s_w", "s_hp", "h_hp"),
+)
+
+
+# Bouwt voor elke aanwezige SOS2-curve een rapport op interval u: welke
+# trappen actief zijn, of ze aangrenzend zijn, en de al-geïnterpoleerde
+# waarde uit de bijbehorende vermogenscontainer.
+def _sos2_reports(model, registry: dict, u: int) -> list[dict]:
+    by_container = _group_by_container(registry)
+    reports: list[dict] = []
+    for label, weight_name, stage_axis, power_name in _SOS2_CURVES:
+        entries = by_container.get(weight_name)
+        if not entries:
+            continue  # this run didn't build this curve (e.g. hp on/off mode)
+        shape = SHAPES[weight_name]
+        u_pos = shape.index("u")
+        stage_pos = shape.index(stage_axis)
+
+        groups: dict[tuple, dict[int, int]] = {}
+        for idx_tuple, var_idx in entries:
+            if idx_tuple[u_pos] != u:
+                continue
+            rest = tuple(
+                v for pos, v in enumerate(idx_tuple) if pos not in (u_pos, stage_pos)
+            )
+            groups.setdefault(rest, {})[idx_tuple[stage_pos]] = var_idx
+
+        power_by_key: dict[tuple, int] = {}
+        power_shape = SHAPES.get(power_name) if power_name else None
+        if power_name and power_shape and "u" in power_shape:
+            p_u_pos = power_shape.index("u")
+            for idx_tuple, var_idx in by_container.get(power_name, []):
+                if idx_tuple[p_u_pos] != u:
+                    continue
+                rest = tuple(v for pos, v in enumerate(idx_tuple) if pos != p_u_pos)
+                power_by_key[rest] = var_idx
+
+        for rest, stage_map in sorted(groups.items()):
+            stages = sorted(stage_map.items())
+            values = [(s, model.vars[vidx].x) for s, vidx in stages]
+            nonzero = [(s, v) for s, v in values if abs(v) > 1e-9]
+            indices = [s for s, _ in nonzero]
+            if len(indices) <= 1:
+                adjacent = True
+            elif len(indices) == 2:
+                adjacent = indices[1] - indices[0] == 1
+            else:
+                adjacent = False
+            interp_idx = power_by_key.get(rest)
+            reports.append(
+                {
+                    "curve": label,
+                    "asset": rest,
+                    "weights": values,
+                    "active_stages": nonzero,
+                    "adjacent": adjacent,
+                    "interpolated": model.vars[interp_idx].x
+                    if interp_idx is not None
+                    else None,
+                }
+            )
+    return reports
+
+
+# Bouwt de sectiesleutel voor de tekstuitvoer: "battery 0", "ev 1", of
+# gewoon "boiler"/"grid" als de container geen asset-as heeft. Neemt de
+# echte indexwaarde uit idx_tuple, niet de as-naam — anders zouden batterij
+# 0 en batterij 1 onder dezelfde sleutel samenvloeien.
+def _section_key(name: str, shape: tuple[str, ...], idx_tuple: tuple) -> str:
+    family = FAMILY.get(name, "other")
+    if shape and shape[0] in _ASSET_AXES:
+        return f"{family} {idx_tuple[0]}"
+    return family
+
+
+# Kernfunctie van A3 (§2.5): alles wat het opgeloste model wist over
+# interval u — elke variabele met leesbaar label, welke constraints
+# bindend zijn, en de SOS2-status van elke aanwezige piecewise-curve.
+# Geeft een structuur terug (geen platte tekst) zodat zowel de tekst- als
+# de --json-weergave van de CLI op dezelfde data werken.
+def dump_interval(model, registry: dict, u: int, *, header: Optional[dict] = None) -> dict:
+    """Everything the solved model knew about interval ``u``: every
+    registered variable touching it, which constraints on it are actually
+    binding, and the SOS2 active-stage/adjacency state for every piecewise
+    curve present in this run. Raises ``VarRegistryError`` if the registry
+    contains a container ``SHAPES`` doesn't know about (§2.5's completeness
+    assertion — a silent gap here is worse than a loud failure, since it
+    would just quietly omit part of the model from every dump)."""
+    _assert_shapes_complete(registry)
+    by_container = _group_by_container(registry)
+
+    sections: dict[str, list[dict]] = {}
+    touched_vars: set[int] = set()
+    for name, entries in by_container.items():
+        shape = SHAPES[name]
+        axis = _interval_axis(shape)
+        if axis is None:
+            continue  # no interval axis at all (e.g. cycle_cost[b])
+        axis_pos, is_boundary = axis
+        wanted = {u, u + 1} if is_boundary else {u}
+        matches = _select_at(entries, axis_pos, wanted)
+        for idx_tuple, var_idx in matches:
+            touched_vars.add(var_idx)
+            section_key = _section_key(name, shape, idx_tuple)
+            sections.setdefault(section_key, []).append(
+                {
+                    "label": name + "".join(f"[{i}]" for i in idx_tuple),
+                    "container": name,
+                    "index": idx_tuple,
+                    "value": model.vars[var_idx].x,
+                    "is_boundary_partner": is_boundary and idx_tuple[axis_pos] == u + 1,
+                }
+            )
+    for entries in sections.values():
+        entries.sort(key=lambda e: e["label"])
+
+    sos2 = _sos2_reports(model, registry, u)
+
+    inv = _inverse_var_constraint_index(model)
+    constraint_ids = sorted({ci for vidx in touched_vars for ci in inv.get(vidx, [])})
+    binding_constraints = [
+        {"index": ci, "text": render_constraint(model.constrs[ci], registry)}
+        for ci in constraint_ids
+        if _is_binding(model.constrs[ci])
+    ]
+
+    # Reduced-detail neighbour context (§2.5 / A3 testing): SoC and
+    # top-level charge/discharge only, no on/off flags, no SOS2, no
+    # constraints — just enough to see the trend across the interval.
+    context_names = ("soc", "ac_to_dc", "ac_from_dc", "c_hp", "c_ev", "c_b")
+    context: dict[str, dict[str, list[dict]]] = {}
+    for neighbour in (u - 1, u + 1):
+        if neighbour < 0:
+            continue
+        neighbour_sections: dict[str, list[dict]] = {}
+        for name in context_names:
+            entries = by_container.get(name)
+            if not entries:
+                continue
+            shape = SHAPES[name]
+            axis = _interval_axis(shape)
+            if axis is None:
+                continue
+            axis_pos, _is_boundary = axis
+            matches = _select_at(entries, axis_pos, {neighbour})
+            for idx_tuple, var_idx in matches:
+                section_key = _section_key(name, shape, idx_tuple)
+                neighbour_sections.setdefault(section_key, []).append(
+                    {
+                        "label": name + "".join(f"[{i}]" for i in idx_tuple),
+                        "value": model.vars[var_idx].x,
+                    }
+                )
+        if neighbour_sections:
+            for entries in neighbour_sections.values():
+                entries.sort(key=lambda e: e["label"])
+            context[str(neighbour)] = neighbour_sections
+
+    return {
+        "interval": u,
+        "header": dict(header) if header else {},
+        "sections": sections,
+        "sos2": sos2,
+        "binding_constraints": binding_constraints,
+        "context": context,
+    }
+
+
+# Formatteert de structuur van dump_interval() als leesbare platte tekst
+# voor stdout; --json op de CLI gebruikt de structuur direct.
+def _format_dump_text(data: dict) -> str:
+    lines: list[str] = []
+    header_bits = [f"interval {data['interval']}"]
+    for k, v in data.get("header", {}).items():
+        if v is not None:
+            header_bits.append(str(v))
+    lines.append("  ".join(header_bits))
+
+    for section_name in sorted(data["sections"]):
+        entries = data["sections"][section_name]
+        lines.append(f"  {section_name}")
+        for e in entries:
+            arrow = " (boundary)" if e.get("is_boundary_partner") else ""
+            lines.append(f"    {e['label']:<28} {e['value']:.4f}{arrow}")
+
+    if data["sos2"]:
+        lines.append("  SOS2 curves")
+        for r in data["sos2"]:
+            asset = f" {r['asset']}" if r["asset"] else ""
+            stages = ", ".join(f"stage {s} (w={v:.4f})" for s, v in r["active_stages"])
+            if not stages:
+                stages = "no active stage"
+            flag = "ok" if r["adjacent"] else "NON-ADJACENT — solver-correctness signal"
+            interp = f"  interpolated={r['interpolated']:.4f}" if r["interpolated"] is not None else ""
+            lines.append(f"    {r['curve']}{asset}: {stages}  [adjacent: {flag}]{interp}")
+
+    lines.append(f"  binding constraints ({len(data['binding_constraints'])})")
+    for bc in data["binding_constraints"]:
+        lines.append(f"    {bc['text']}")
+
+    for neighbour, sections in data.get("context", {}).items():
+        if not sections:
+            continue
+        lines.append(f"  context u={neighbour}")
+        for section_name in sorted(sections):
+            for e in sections[section_name]:
+                lines.append(f"    {e['label']:<28} {e['value']:.4f}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # CLI (A6, §13)
 # ---------------------------------------------------------------------------
 #
@@ -1729,16 +2287,127 @@ def cmd_set(args: argparse.Namespace, data_dir: Path) -> int:
     return EXIT_OK
 
 
-# Stub: dump_interval bestaat nog niet, dit commando geeft een duidelijke melding in plaats van te crashen.
+# Best-effort (tijdstip, prijs-levering, prijs-teruglevering) voor de dump-
+# header; faalt nooit — geeft (None, None, None) bij twijfel in plaats van
+# een mogelijk verkeerde prijs te tonen. Rondt captured_at af op de
+# intervalgrens en zoekt de dichtstbijzijnde rij in het opgenomen
+# price_data (niet prog_data — dat laatste krijgt da_cons/da_prod pas
+# tijdens calc_optimum() zelf, dus de opgenomen kopie heeft die kolommen
+# nog niet).
+def _lookup_price_at_interval(
+    replay: "ReplayIO", meta: dict, u: int
+) -> tuple[Optional[dt.datetime], Optional[float], Optional[float]]:
+    try:
+        captured_at = meta.get("captured_at")
+        interval_str = meta.get("interval")
+        price_data = getattr(replay, "_price_data", None)
+        if not captured_at or not interval_str or price_data is None:
+            return None, None, None
+        if "time" not in price_data.columns:
+            return None, None, None
+        interval_s = 3600 if interval_str == "1hour" else 900
+        start = dt.datetime.fromisoformat(captured_at)
+        if interval_s == 3600:
+            rounded = start.replace(minute=0, second=0, microsecond=0)
+        else:
+            rounded = start.replace(
+                minute=(start.minute // 15) * 15, second=0, microsecond=0
+            )
+        target = rounded + dt.timedelta(seconds=interval_s * u)
+        times = pd.to_datetime(price_data["time"]).dt.tz_localize(None)
+        deltas = (times - target.replace(tzinfo=None)).abs()
+        pos = int(deltas.values.argmin())
+        if deltas.iloc[pos] > dt.timedelta(seconds=interval_s / 2):
+            return None, None, None
+        row = price_data.iloc[pos]
+        da_cons = float(row["da_cons"]) if "da_cons" in price_data.columns else None
+        da_prod = float(row["da_prod"]) if "da_prod" in price_data.columns else None
+        return target, da_cons, da_prod
+    except Exception:  # noqa: BLE001 - header enrichment only, never fatal
+        return None, None, None
+
+
+# Zoekt de hoogste interval-index die daadwerkelijk in de registry
+# voorkomt, om --interval tegen een zinnig bereik te kunnen valideren
+# zonder dat de CLI U apart hoeft te kennen.
+def _max_known_interval(registry: dict) -> int:
+    max_u = -1
+    for _var_idx, (name, idx_tuple) in registry.items():
+        shape = SHAPES.get(name)
+        if not shape:
+            continue
+        if "u" in shape:
+            max_u = max(max_u, idx_tuple[shape.index("u")])
+        elif "u_boundary" in shape:
+            max_u = max(max_u, idx_tuple[shape.index("u_boundary")] - 1)
+    return max_u
+
+
+# Speelt een snapshot af met _debug_capture_vars aan, zodat A1's hook in
+# day_ahead.py de variabele-registry opbouwt, en dumpt daarna interval
+# --interval: alles wat het opgeloste model erover wist.
 def cmd_dump(args: argparse.Namespace, data_dir: Path) -> int:
-    message = (
-        "dump is not implemented yet: it needs the variable registry "
-        "(architecture doc §2.3/§2.5), which is separate follow-up work "
-        "(A3), not part of this session."
-    )
-    data = {"error": message}
-    _emit(args, data, lambda d: print(d["error"]))
-    return EXIT_USAGE
+    if not args.snapshot:
+        raise UsageError("dump requires --snapshot PATH")
+    if args.interval is None:
+        raise UsageError("dump requires --interval N")
+
+    snapshot_path = _resolve_snapshot_arg(data_dir, args.snapshot)
+    if not snapshot_path.exists():
+        raise UsageError(f"Snapshot not found: {snapshot_path}")
+
+    _ensure_day_ahead_importable()
+    from dao.prog.day_ahead import DaCalc
+
+    guard = _offline_guard() if args.offline else None
+    try:
+        with ReplayIO(snapshot_path, solver_threads=args.threads) as replay:
+            dacalc = DaCalc(str(snapshot_path))
+            dacalc._debug_capture_vars = True
+            result = dacalc.calc_optimum()
+        model = replay._model
+        registry = getattr(dacalc, "_debug_vars", None)
+        meta = replay.meta
+    finally:
+        if guard is not None:
+            _offline_unguard(guard)
+
+    if model is None or result is None:
+        raise UsageError(
+            "replay never reached a solved model.optimize() — nothing to "
+            "dump (see any error logged above)"
+        )
+    if not registry:
+        raise UsageError(
+            "no variable registry was captured: day_ahead.py's hook imports "
+            "'da_debug' as a bare module name, which only resolves once "
+            "dao/prog is on sys.path — that should already be arranged by "
+            "this CLI, so this points at a real problem, not a missing flag"
+        )
+
+    max_u = _max_known_interval(registry)
+    if max_u >= 0 and not (0 <= args.interval <= max_u):
+        raise UsageError(
+            f"--interval {args.interval} is out of range for this run "
+            f"(intervals 0..{max_u})"
+        )
+
+    timestamp, da_cons, da_prod = _lookup_price_at_interval(replay, meta, args.interval)
+    header = {
+        "dao_version": meta.get("dao_version"),
+        "solver": getattr(model, "solver_name", None),
+        "snapshot": str(snapshot_path),
+    }
+    if timestamp is not None:
+        header["timestamp"] = timestamp.isoformat(sep=" ", timespec="minutes")
+    if da_cons is not None:
+        header["price_cons"] = round(da_cons, 4)
+    if da_prod is not None:
+        header["price_prod"] = round(da_prod, 4)
+
+    data = dump_interval(model, registry, args.interval, header=header)
+    _emit(args, data, lambda d: print(_format_dump_text(d)))
+    return EXIT_OK
 
 
 # Interne zelftest voor precies het scenario dat DaBase.get_state raakt: een geërfde, niet-eigen methode moet na restore weer via de klasse-hiërarchie lopen.
@@ -1764,6 +2433,67 @@ def _patch_list_restore_check() -> None:
         raise AssertionError("inherited attribute was not correctly un-shadowed")
     if Owner().greet() != "base":
         raise AssertionError("patch did not restore correctly")
+
+
+# Bouwt een klein maar structureel representatief 1-batterij/2-interval
+# SOS2-laad/ontlaadmodel (dezelfde vorm als day_ahead.py's echte battery-
+# sectie: ac_to_dc_w/ac_from_dc_w als SOS2-gewichten, soc als U+1-grens),
+# lost het op, en geeft (model, registry) terug — gebruikt door meerdere
+# A3-zelftests zodat die niet elk hun eigen kopie van de modelopbouw nodig
+# hebben.
+def _build_synthetic_sos2_model():
+    from mip import Model, xsum, BINARY, CONTINUOUS, maximize
+
+    B, U, CS, DS = 1, 2, 2, 2
+    ac_to_dc_samples = [[0.0, 5.0]]
+    dc_from_ac_samples = [[0.0, 4.5]]
+    ac_from_dc_samples = [[0.0, 3.0]]
+    dc_to_ac_samples = [[0.0, 3.3]]
+
+    model = Model()
+    ac_to_dc = [[model.add_var(var_type=CONTINUOUS, lb=0, ub=5) for _ in range(U)] for _ in range(B)]
+    ac_to_dc_on = [[model.add_var(var_type=BINARY) for _ in range(U)] for _ in range(B)]
+    ac_to_dc_w = [[[model.add_var(var_type=CONTINUOUS, lb=0, ub=1) for _ in range(CS)] for _ in range(U)] for _ in range(B)]
+    ac_from_dc = [[model.add_var(var_type=CONTINUOUS, lb=0, ub=3) for _ in range(U)] for _ in range(B)]
+    ac_from_dc_on = [[model.add_var(var_type=BINARY) for _ in range(U)] for _ in range(B)]
+    ac_from_dc_w = [[[model.add_var(var_type=CONTINUOUS, lb=0, ub=1) for _ in range(DS)] for _ in range(U)] for _ in range(B)]
+    dc_from_ac = [[model.add_var(var_type=CONTINUOUS, lb=0, ub=4.5) for _ in range(U)] for _ in range(B)]
+    dc_to_ac = [[model.add_var(var_type=CONTINUOUS, lb=0, ub=3.3) for _ in range(U)] for _ in range(B)]
+    dc_from_bat = [[model.add_var(var_type=CONTINUOUS, lb=0, ub=3.3) for _ in range(U)] for _ in range(B)]
+    dc_to_bat = [[model.add_var(var_type=CONTINUOUS, lb=0, ub=4.5) for _ in range(U)] for _ in range(B)]
+    soc = [[model.add_var(var_type=CONTINUOUS, lb=0, ub=100) for _ in range(U + 1)] for _ in range(B)]
+
+    for b in range(B):
+        model += soc[b][0] == 50
+        for u in range(U):
+            model += xsum(ac_to_dc_w[b][u][cs] for cs in range(CS)) == 1
+            model += xsum(ac_to_dc_w[b][u][cs] * ac_to_dc_samples[b][cs] for cs in range(CS)) == ac_to_dc[b][u]
+            model += xsum(ac_to_dc_w[b][u][cs] * dc_from_ac_samples[b][cs] for cs in range(CS)) == dc_from_ac[b][u]
+            model.add_sos([(ac_to_dc_w[b][u][cs], ac_to_dc_samples[b][cs]) for cs in range(CS)], 2)
+
+            model += xsum(ac_from_dc_w[b][u][ds] for ds in range(DS)) <= 1
+            model += xsum(ac_from_dc_w[b][u][ds] * ac_from_dc_samples[b][ds] for ds in range(DS)) == ac_from_dc[b][u]
+            model += xsum(ac_from_dc_w[b][u][ds] * dc_to_ac_samples[b][ds] for ds in range(DS)) == dc_to_ac[b][u]
+            model.add_sos([(ac_from_dc_w[b][u][ds], ac_from_dc_samples[b][ds]) for ds in range(DS)], 2)
+
+            model += dc_from_ac[b][u] <= ac_to_dc_on[b][u] * 5
+            model += ac_from_dc[b][u] <= ac_from_dc_on[b][u] * 3
+            model += ac_to_dc_on[b][u] + ac_from_dc_on[b][u] <= 1
+
+            model += dc_from_ac[b][u] + dc_from_bat[b][u] == dc_to_ac[b][u] + dc_to_bat[b][u]
+            model += soc[b][u + 1] == soc[b][u] + dc_to_bat[b][u] - dc_from_bat[b][u]
+
+    # Force interval 1 idle so a dump of it is a small, quiet contrast to
+    # interval 0's forced full-power charge (mirrors the "idle interval ->
+    # short binding-constraint list" check from the A3 testing section).
+    model += dc_to_bat[0][1] == 0
+    model += dc_from_bat[0][1] == 0
+    model.objective = maximize(dc_to_bat[0][0])
+    model.verbose = 0
+    model.optimize()
+
+    registry = build_var_registry(locals())
+    return model, registry
 
 
 # Draait alle offline zelftests van da_debug.py, zonder dat daar een live stack voor nodig is.
@@ -1816,12 +2546,93 @@ def cmd_selftest(args: argparse.Namespace, data_dir: Path) -> int:
             raise AssertionError("leak gate did not fire on a planted secret")
         _assert_no_secret_leak('{"x": "clean"}', ["leak-me"])  # must not raise
 
+    # Bouwt uit een geneste synthetische structuur de registry op en
+    # controleert dat een bekende Var op het juiste containernaam+indexpad
+    # terugkomt — dit is waar registry-bugs echt zitten (A1 Testing #2).
+    def _var_registry_nested_containers():
+        if mip is None:
+            return  # mip not installed: nothing to test against
+        model = mip.Model()
+        flat = [model.add_var(var_type=mip.CONTINUOUS) for _ in range(2)]
+        nested = [
+            [[model.add_var(var_type=mip.BINARY) for _k in range(2)] for _j in range(2)]
+            for _i in range(2)
+        ]
+        not_a_container = 3.14  # must be skipped, not walked
+        registry = build_var_registry(locals())
+        if registry.get(flat[1].idx) != ("flat", (1,)):
+            raise AssertionError("flat container entry missing or wrong")
+        if registry.get(nested[1][0][1].idx) != ("nested", (1, 0, 1)):
+            raise AssertionError("nested container entry missing or wrong index path")
+        if len(registry) != len(flat) + 8:  # 2 + 2*2*2
+            raise AssertionError(f"unexpected registry size {len(registry)}")
+
+    # Controleert dat de volledigheidscontrole afgaat op een containernaam
+    # die niet in SHAPES/SHAPES_IGNORE staat (A3 Testing: "add a container
+    # without updating SHAPES").
+    def _shapes_completeness_fires_on_unknown_container():
+        bad_registry = {0: ("mystery_container_nobody_declared", (0,))}
+        try:
+            _assert_shapes_complete(bad_registry)
+        except VarRegistryError:
+            pass
+        else:
+            raise AssertionError("completeness assertion did not fire on an unknown container")
+        _assert_shapes_complete({0: ("soc", (0, 0))})  # must not raise on a known one
+
+    # End-to-end: los het synthetische SOS2-model op en controleer dat
+    # dump_interval op de dwangmatig ladende interval de juiste vermogens,
+    # soc-in/out, en een aangrenzende actieve SOS2-trap teruggeeft, en dat
+    # de gerenderde binding constraints geen "var(N)"-fallback bevatten
+    # (d.w.z. dat elke variabele daadwerkelijk een registry-label kreeg).
+    def _dump_interval_charging_interval():
+        if mip is None:
+            return
+        model, registry = _build_synthetic_sos2_model()
+        data = dump_interval(model, registry, 0, header={"dao_version": "selftest"})
+        by_label = {e["label"]: e["value"] for e in data["sections"]["battery 0"]}
+        if abs(by_label["ac_to_dc[0][0]"] - 5.0) > 1e-6:
+            raise AssertionError("charging interval did not reach full charge power")
+        if abs(by_label["soc[0][0]"] - 50.0) > 1e-6 or abs(by_label["soc[0][1]"] - 54.5) > 1e-6:
+            raise AssertionError("soc in/out did not match the forced charge")
+        charge_curve = next(r for r in data["sos2"] if r["curve"] == "battery charge")
+        if not charge_curve["adjacent"] or not charge_curve["active_stages"]:
+            raise AssertionError("SOS2 charge curve should report one adjacent active stage")
+        if abs(charge_curve["interpolated"] - by_label["ac_to_dc[0][0]"]) > 1e-6:
+            raise AssertionError("SOS2 interpolated power should equal ac_to_dc[0][0]")
+        if not data["binding_constraints"]:
+            raise AssertionError("a forced-charge interval should have binding constraints")
+        if any("var(" in bc["text"] for bc in data["binding_constraints"]):
+            raise AssertionError("a binding constraint fell back to var(N) — a registered var wasn't labelled")
+        if "-0" in _format_dump_text(data):
+            raise AssertionError("rendered output contains a stray -0 (negative-zero formatting bug)")
+
+    # Idle interval (dwongen tot 0 laden/ontladen): moet nog steeds netjes
+    # dumpen zonder te crashen, en zonder een van de over-matching
+    # symptomen (een lege binding-constraint-lijst zou juist verdacht zijn
+    # geweest — hier moet de energie-balans/soc-koppeling nog steeds
+    # binding zijn).
+    def _dump_interval_idle_interval():
+        if mip is None:
+            return
+        model, registry = _build_synthetic_sos2_model()
+        data = dump_interval(model, registry, 1)
+        by_label = {e["label"]: e["value"] for e in data["sections"]["battery 0"]}
+        if abs(by_label["ac_to_dc[0][1]"]) > 1e-6 or abs(by_label["ac_from_dc[0][1]"]) > 1e-6:
+            raise AssertionError("forced-idle interval should show zero flow")
+        if not data["context"].get("0"):
+            raise AssertionError("interval 1 should carry reduced context for its u=0 neighbour")
+
     for name, fn in [
         ("dataframe_roundtrip", _dataframe_roundtrip),
         ("call_key_stability", _call_key_stability),
         ("config_hash_determinism", _config_hash_determinism),
         ("secret_leak_gate", _secret_leak_gate),
         ("patch_list_restore", _patch_list_restore_check),
+        ("var_registry_nested_containers", _var_registry_nested_containers),
+        ("shapes_completeness_fires_on_unknown_container", _shapes_completeness_fires_on_unknown_container),
+        ("dump_interval_charging_interval", _dump_interval_charging_interval),
+        ("dump_interval_idle_interval", _dump_interval_idle_interval),
     ]:
         check(name, fn)
 
@@ -1971,9 +2782,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--state", action="append", default=[], metavar="entity_id=value", help="Repeatable.")
     p.add_argument("--out", required=True)
 
-    p = sub.add_parser("dump", parents=[common], help="Interval dump (stub — needs A3's variable registry).")
-    p.add_argument("--snapshot", default=None)
-    p.add_argument("--interval", type=int, default=None)
+    p = sub.add_parser("dump", parents=[common], help="Replay a snapshot and print everything the solved model knew about one interval.")
+    p.add_argument("--snapshot", default=None, required=True)
+    p.add_argument("--interval", type=int, default=None, required=True, metavar="U")
+    p.add_argument("--offline", dest="offline", action="store_true", default=True, help="Block all network access during the replay this needs (default).")
+    p.add_argument("--allow-network", dest="offline", action="store_false", help="Disable the network block (escape hatch).")
+    p.add_argument(
+        "--threads",
+        type=int,
+        default=-1,
+        metavar="N",
+        help="CBC thread count for the replay dump reads from (same semantics as `replay --threads`). Default -1.",
+    )
 
     sub.add_parser("selftest", parents=[common], help="Run da_debug's own offline checks.")
 
@@ -2021,6 +2841,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     except UsageError as ex:
         _print_error(args, "usage-error", ex)
         return EXIT_USAGE
+    except VarRegistryError as ex:
+        _print_error(args, "assertion-failed", ex)
+        return EXIT_ASSERTION_FAILED
 
 
 if __name__ == "__main__":

--- a/dao/prog/da_debug.py
+++ b/dao/prog/da_debug.py
@@ -1,0 +1,2027 @@
+"""
+Snapshot capture and hermetic replay for ``DaCalc.calc_optimum()``.
+
+See ``dao_debug_replay_ci_architecture_v2.md`` sections 2.1 and 2.2 for the
+design this implements. In short: ``calc_optimum()`` crosses several
+external-state boundaries (database, Home Assistant REST, the wall clock,
+the on-disk config) before and during a solve. This module patches those
+boundaries at the class/module level — never touching ``day_ahead.py``
+itself beyond the two additive hooks already landed there — so that a run
+can either be recorded to a fixture file (``RecordingIO``) or replayed
+hermetically from one (``ReplayIO``), with no live Home Assistant and no
+database connection required for the latter.
+
+Usage::
+
+    with RecordingIO(out_dir="../data/debug_snapshots") as rec:
+        dacalc = DaCalc("../data/options.json")
+        dacalc.calc_optimum()
+    print(rec.snapshot_path)
+
+    with ReplayIO(rec.snapshot_path):
+        dacalc = DaCalc("../data/options.json")  # never touches disk/DB/HA
+        dacalc.calc_optimum()
+
+Both classes are context managers that must be entered *before* any
+``DaBase``-family object (``DaCalc``, ``Report``) is constructed, since some
+of the channels they patch (config, strategy resolution, the HA REST call in
+the constructor) are read inside ``DaBase.__init__`` itself.
+
+Only the input cut-set (§2.1) and the snapshot format (§2.2) are implemented
+here. The variable registry and ``dump_interval`` (§2.3-§2.5) are a
+separate, later piece of work; ``RecordingIO`` does not depend on them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import io
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+try:
+    import mip
+except ImportError:  # pragma: no cover - mip is a hard project dependency,
+    mip = None  # but da_debug.py should still be importable without it.
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+SCHEMA_MIN_SUPPORTED = 1
+
+REDACTED_SECRET = "<redacted:SecretStr>"
+
+
+class SnapshotMiss(RuntimeError):
+    """Raised by ReplayIO when a replayed run asks for input the snapshot
+    does not have. Never caught internally — a stale or incomplete fixture
+    must fail loudly, not silently fall back to live/default behaviour."""
+
+
+# ---------------------------------------------------------------------------
+# Config sanitisation / reconstruction (A0 Q9 / §2.2)
+# ---------------------------------------------------------------------------
+
+
+# Zet een pydantic-configwaarde recursief om naar JSON-veilige data en 
+# vervangt elk SecretStr-veld door een redactiemarkering, zodat geheimen nooit in een snapshot belanden.
+def _sanitize_config_value(value: Any) -> Any:
+    """Recursively convert a pydantic config object graph into a
+    JSON-safe structure, dropping every ``SecretStr`` field by type.
+
+    Walks the live object graph (not a ``model_dump()`` result) because
+    ``SecretStr`` has no custom pydantic serializer, so a dump would already
+    have coerced it to a plain ``str`` and lost the type identity needed to
+    tell a secret field apart from an ordinary one.
+    """
+    from dao.prog.config.models.base import SecretStr
+    from pydantic import BaseModel
+    from enum import Enum
+
+    if isinstance(value, SecretStr):
+        return REDACTED_SECRET
+    if isinstance(value, BaseModel):
+        return {
+            name: _sanitize_config_value(getattr(value, name))
+            for name in type(value).model_fields
+        }
+    if isinstance(value, dict):
+        return {str(k): _sanitize_config_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_config_value(v) for v in value]
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, (dt.datetime, dt.date)):
+        return value.isoformat()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    # Best-effort fallback for anything unforeseen; never raise here, a
+    # capture failure must not abort the real run.
+    return str(value)
+
+
+# Kleine wrapper rond _sanitize_config_value voor het hele configobject, 
+# apart gehouden zodat het aanroeppunt een eigen naam heeft.
+def _sanitize_config(config: Any) -> dict:
+    return _sanitize_config_value(config)
+
+
+# Bouwt uit een gesaneerde snapshot-dict weer een gevalideerd pydantic-configobject, 
+# nodig om DaBase te kunnen construeren zonder een echte options.json.
+def _rehydrate_config(sanitized: dict):
+    """Reconstruct a validated pydantic config object from a sanitised
+    snapshot dict. ``SecretStr`` fields come back as the literal
+    ``REDACTED_SECRET`` marker string, which is harmless: everything that
+    reads a secret during replay (only ``hasstoken``/``meteoserver_key`` via
+    ``.resolve()`` inside ``DaBase.__init__``) treats an unresolvable value
+    as a plain literal and returns it as-is; nothing that needs a *working*
+    secret is reachable during a patched replay (price/HP-hours lookups are
+    replaced wholesale before they would ever call out with one)."""
+    from dao.prog.config.loader import VERSION_MODELS, CURRENT_VERSION
+
+    version = sanitized.get("config_version", CURRENT_VERSION)
+    model_class = VERSION_MODELS.get(version, VERSION_MODELS[CURRENT_VERSION])
+    return model_class(**sanitized)
+
+
+# Berekent een sha256-hash over de gesaneerde config, 
+# gebruikt om drift tussen een snapshot en de actuele config te detecteren.
+def _config_hash(sanitized: dict) -> str:
+    blob = json.dumps(sanitized, sort_keys=True, default=str).encode("utf-8")
+    return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+# Weigert de snapshot te schrijven als een echte geheime waarde uit secrets.json 
+# letterlijk in de inhoud voorkomt; vangt lekken die de typecontrole mist.
+def _assert_no_secret_leak(blob: str, secret_values: list[str]) -> None:
+    """Defence in depth alongside type-based exclusion (§2.2): a raw key
+    pasted into options.json instead of a ``!secret`` reference never
+    becomes a ``SecretStr`` the sanitiser can catch by type, but it *is* a
+    value that also lives in secrets.json — this catches that case."""
+    leaked = [v for v in secret_values if v and v in blob]
+    if leaked:
+        raise RuntimeError(
+            f"Refusing to write snapshot: {len(leaked)} secret value(s) "
+            f"from secrets.json appear in the sanitised snapshot content. "
+            f"This should be impossible after type-based SecretStr "
+            f"redaction and indicates either a new secret-bearing field "
+            f"that isn't SecretStr-typed, or a secret value that also "
+            f"happens to appear literally in non-secret config/data."
+        )
+
+
+# ---------------------------------------------------------------------------
+# DataFrame <-> JSON payload (§2.2)
+# ---------------------------------------------------------------------------
+
+
+# Serialiseert een DataFrame naar JSON met expliciete dtypes en index-type,
+# want standaard-JSON rondt floats af en kent geen datetime-index.
+def _dataframe_to_payload(df: pd.DataFrame) -> dict:
+    return {
+        "data": df.to_json(orient="split", date_format="iso", double_precision=15),
+        "dtypes": {str(c): str(t) for c, t in df.dtypes.items()},
+        "index_name": df.index.name,
+        "index_is_datetime": isinstance(df.index, pd.DatetimeIndex),
+    }
+
+
+# Herstelt een DataFrame exact uit een payload: dtypes terugzetten 
+# en de index alleen naar datetime converteren als die dat origineel ook was.
+def _dataframe_from_payload(payload: dict) -> pd.DataFrame:
+    df = pd.read_json(io.StringIO(payload["data"]), orient="split")
+    for col, dtype in payload.get("dtypes", {}).items():
+        if col not in df.columns:
+            continue
+        try:
+            if dtype.startswith("datetime64"):
+                df[col] = pd.to_datetime(df[col])
+            else:
+                df[col] = df[col].astype(dtype)
+        except (TypeError, ValueError) as ex:
+            logger.warning("Kon dtype %s van kolom %s niet herstellen: %s", dtype, col, ex)
+    # Only coerce the index to datetime if it genuinely was one — blindly
+    # doing this for every non-empty frame (the original bug) silently
+    # corrupted plain integer/RangeIndex frames, e.g. solar_predictions'
+    # results, which have no datetime index at all.
+    if payload.get("index_is_datetime"):
+        df.index = pd.to_datetime(df.index)
+    df.index.name = payload.get("index_name")
+    return df
+
+
+# Maakt een stabiele, JSON-veilige sleutel van functieargumenten, 
+# nodig om meerdere opnames van dezelfde aanroep (per weekdag, per entity) uit elkaar te houden.
+def _call_key(args: tuple, kwargs: dict) -> str:
+    """Stable, JSON-safe key for a recorded call, used where a channel can
+    legitimately be invoked more than once with different arguments
+    (``get_calculated_baseload(weekday)``, ``get_heatpump_run_hours(entity)``)."""
+    return json.dumps([list(args), sorted(kwargs.items())], default=str, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stand-ins used only during replay
+# ---------------------------------------------------------------------------
+
+
+class _FakeState:
+    """Minimal stand-in for whatever hassapi's ``get_state()`` normally
+    returns. Every call site in day_ahead.py/da_base.py only ever reads
+    ``.state`` off the result (verified by grep) so nothing else is
+    implemented."""
+
+    __slots__ = ("state",)
+
+    # Bewaart alleen de state-string; dat is het enige dat aanroepers van get_state() ooit uitlezen.
+    def __init__(self, state: str):
+        self.state = state
+
+
+class _FakeHttpResponse:
+    """Stand-in for a ``requests.Response``. Serves two distinct real call
+    sites during replay: the raw ``get(hassurl + "api/config")`` in
+    ``DaBase.__init__`` (reads only ``.text``), and — discovered by actually
+    running a hermetic construction against the real ``hassapi`` package,
+    not just reading it — ``hass.Hass.__init__`` itself, via
+    ``BaseClient._assert_api_running()``, which does its own independent
+    ``requests.get("<hassurl>/")`` health check and reads ``.ok``/``.json()``
+    on the result. Supporting all three keeps both call sites served by one
+    small stand-in."""
+
+    __slots__ = ("_payload", "text", "ok", "status_code")
+
+    # Bouwt een minimale requests.Response-imitatie met .text/.ok/.status_code, 
+    # nodig om zowel da_base.py's eigen HA-aanroep als hassapi's interne verzoek te kunnen bedienen.
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.text = json.dumps(payload)
+        self.ok = True
+        self.status_code = 200
+
+    # Geeft de payload terug zoals requests.Response.json() dat zou doen, 
+    # want hassapi's interne verwerking roept dit aan.
+    def json(self):
+        return self._payload
+
+
+class _FakeDbManager:
+    """Stand-in for the ``DBmanagerObj`` singleton ``make_db_da``/
+    ``make_db_ha`` normally return. Serves the one channel calc_optimum()
+    calls directly (``get_prognose_data``); everything else raises loudly
+    rather than silently returning something DB-shaped, since a call
+    reaching here that isn't one of the two known methods means the input
+    cut-set (§1) is incomplete and a new channel needs a real patch."""
+
+    # Onthoudt de opgeslagen prognosedata en een label voor duidelijke foutmeldingen.
+    def __init__(self, prog_data: Optional[pd.DataFrame], label: str):
+        self._prog_data = prog_data
+        self._label = label
+
+    # Levert de opgeslagen prognosedata terug in plaats van een echte databasequery uit te voeren.
+    def get_prognose_data(self, start=None, end=None, interval="1hour"):
+        if self._prog_data is None:
+            raise SnapshotMiss(
+                f"ReplayIO ({self._label}): prog_data not present in snapshot"
+            )
+        return self._prog_data.copy()
+
+    # Doet niets; bestaat alleen omdat DaBase.__init__ dit aanroept en anders een AttributeError zou geven.
+    def log_pool_status(self):
+        return None
+
+    # Laat elke niet-nagebouwde databaseaanroep direct hard falen, 
+    # zodat een ongedekt kanaal opvalt in plaats van stilzwijgend een verkeerd resultaat te geven.
+    def __getattr__(self, name):
+        raise SnapshotMiss(
+            f"ReplayIO ({self._label}): db_da/db_ha.{name}() was called, but "
+            f"ReplayIO only serves get_prognose_data()/log_pool_status(). "
+            f"This means a channel outside the documented input cut-set "
+            f"(architecture doc §1) was reached during replay."
+        )
+
+
+class _FakeLoader:
+    """Stand-in for ``ConfigurationLoader`` used only to satisfy
+    ``self.loader.secrets`` during replay. Always empty: no real secrets are
+    ever needed for a replayed run (see ``_rehydrate_config``)."""
+
+    secrets: dict = {}
+
+
+# ---------------------------------------------------------------------------
+# Patch bookkeeping shared by RecordingIO and ReplayIO
+# ---------------------------------------------------------------------------
+
+
+class _PatchList:
+    """Tracks class/module attribute overrides so they can be reverted
+    exactly, including the case where the attribute didn't exist directly on
+    the target before (e.g. ``DaBase.get_state`` is inherited from
+    ``hass.Hass``, not defined on ``DaBase`` itself) — restoring must
+    ``delattr`` in that case, not set back a value that was never really
+    there, or the shadow would survive patch removal."""
+
+    # Start met een lege lijst van toegepaste patches.
+    def __init__(self):
+        self._entries: list[tuple[Any, str, bool, Any]] = []
+
+    # Vervangt een attribuut en onthoudt de oorspronkelijke waarde (of het ontbreken ervan), 
+    # nodig om later exact te kunnen herstellen.
+    def set(self, target: Any, name: str, new_value: Any) -> None:
+        had_attr = name in vars(target)
+        old_value = vars(target).get(name)
+        self._entries.append((target, name, had_attr, old_value))
+        setattr(target, name, new_value)
+
+    # Zet alle patches in omgekeerde volgorde terug, inclusief delattr voor attributen die er origineel niet waren, 
+    # zoals een geërfde methode.
+    def restore(self) -> None:
+        for target, name, had_attr, old_value in reversed(self._entries):
+            try:
+                if had_attr:
+                    setattr(target, name, old_value)
+                else:
+                    delattr(target, name)
+            except AttributeError:
+                logger.warning("Kon patch op %s.%s niet ongedaan maken", target, name)
+        self._entries.clear()
+
+
+# Importeert alle te patchen klassen via hetzelfde dotted pad als day_ahead.py zelf, 
+# anders ontstaat een tweede, ongepatchte kopie van de module.
+def _import_targets():
+    """All patch targets, imported via the exact same dotted path
+    day_ahead.py itself uses. This matters: importing e.g. ``da_report``
+    (bare) instead of ``dao.prog.da_report`` would create a *second* module
+    object under a different ``sys.modules`` key, with its own distinct
+    ``Report`` class — patching that copy would silently do nothing to the
+    class day_ahead.py actually constructs (A0 Q2)."""
+    from dao.prog.da_base import DaBase
+    from dao.prog.da_report import Report
+    from dao.lib.db_manager import DBmanagerObj
+    from dao.prog.solar_predictor import SolarPredictor
+    import dao.prog.da_base as da_base_module
+
+    return DaBase, Report, DBmanagerObj, SolarPredictor, da_base_module
+
+
+# ---------------------------------------------------------------------------
+# Write-primitive no-ops, shared by ReplayIO (always) and RecordingIO's
+# opt-in debug mode (§ "capture --debug"). Suppressing at these primitives
+# rather than chasing call sites is the same principle used for every read
+# channel above: the boundary is the stable thing, the call sites are not.
+# ---------------------------------------------------------------------------
+
+
+# Bouwt een set_value-vervanger die niets doet, gebruikt om HA-writes te onderdrukken tijdens replay en debug-capture.
+def _make_noop_set_value(label: str):
+    # Logt de onderdrukte write en geeft None terug in plaats van echt naar HA te schrijven.
+    def _noop_set_value(instance, entity_id, value):
+        logger.debug("%s: onderdrukt write set_value(%s, %s)", label, entity_id, value)
+        return None
+
+    return _noop_set_value
+
+
+# Zelfde principe als _make_noop_set_value, maar voor call_service.
+def _make_noop_call_service(label: str):
+    # Onderdrukt een service-aanroep naar HA.
+    def _noop_call_service(instance, *args, **kwargs):
+        logger.debug("%s: onderdrukt write call_service%s %s", label, args, kwargs)
+        return None
+
+    return _noop_call_service
+
+
+# Onderdrukt het wegschrijven van de PNG-afbeelding die day_ahead.py ongeacht debug-modus altijd maakt.
+def _make_noop_savefig(label: str):
+    # Doet niets in plaats van een bestand op schijf te zetten.
+    def _noop_savefig(*args, **kwargs):
+        logger.debug("%s: onderdrukt write plt.savefig%s", label, args)
+        return None
+
+    return _noop_savefig
+
+
+# ---------------------------------------------------------------------------
+# Solved-model capture, shared by RecordingIO (always) and ReplayIO (so a
+# replay produces its own *.result.json too — otherwise there is nothing to
+# `diff` a replay's objective/gap/status against, live or from a capture).
+# ---------------------------------------------------------------------------
+
+
+# Omwikkelt day_ahead.py's fd-omleiding zodat de CBC-solverlog altijd wordt vastgelegd, 
+# ook als self.debug uit staat.
+def _install_cbc_log_capture(patches: "_PatchList", day_ahead_module, target) -> None:
+    """Wraps day_ahead.py's fd-redirecting ``_capture_native_stdout()`` so
+    the CBC solve text lands in ``target._cbc_log_chunks`` unconditionally —
+    day_ahead.py only *logs* it when ``self.debug or log_level <= DEBUG``,
+    but the text itself is always produced regardless. Preserves the real
+    redirection exactly; ``native`` is read only after the real
+    implementation's own ``finally`` has already populated it."""
+    import contextlib
+
+    original = day_ahead_module._capture_native_stdout
+
+    @contextlib.contextmanager
+    # Roept de echte fd-omleiding aan en leest het logresultaat pas uit nadat 
+    # de originele implementatie het heeft gevuld.
+    def _wrapped_capture_native_stdout():
+        with original() as native:
+            yield native
+        target._cbc_log_chunks.append(native.get("cbc_log", ""))
+
+    patches.set(day_ahead_module, "_capture_native_stdout", _wrapped_capture_native_stdout)
+
+
+# Onthoudt een referentie naar het opgeloste mip.Model na elke optimize()-aanroep, want buiten calc_optimum() is dat model anders nergens meer te zien.
+def _install_model_capture(patches: "_PatchList", target) -> None:
+    """Records a reference to the ``mip.Model`` instance after each
+    ``optimize()`` call, so objective/status/gap are readable afterward —
+    without this, nothing outside ``calc_optimum()`` can see the solved
+    model at all, since it's a local variable there."""
+    if mip is None:
+        return
+    original_optimize = mip.Model.optimize
+
+    # Voert de echte solve uit en bewaart daarna het modelobject.
+    def _wrapped_optimize(model_self, *args, **kwargs):
+        status = original_optimize(model_self, *args, **kwargs)
+        target._model = model_self
+        return status
+
+    patches.set(mip.Model, "optimize", _wrapped_optimize)
+
+
+# Zet een opgelost model om naar een result-dict, gedeeld door RecordingIO en ReplayIO zodat beide dezelfde vorm opleveren om te diffen.
+def _build_result_dict(model, cbc_log_chunks: list[str], extra_meta: dict) -> Optional[dict]:
+    if model is None:
+        return None
+    try:
+        return {
+            "meta": {
+                "dao_version": _dao_version(),
+                "solver": getattr(model, "solver_name", None),
+                "mip_version": getattr(mip, "__version__", None) if mip else None,
+                **extra_meta,
+            },
+            "objective_value": model.objective_value,
+            "objective_bound": model.objective_bound,
+            "status": getattr(model.status, "name", str(model.status)),
+            "num_solutions": model.num_solutions,
+            "num_cols": model.num_cols,
+            "num_rows": model.num_rows,
+            "gap": model.gap,
+            "cbc_log": "\n".join(cbc_log_chunks) if cbc_log_chunks else None,
+            "note": (
+                "Per-interval dispatch and SoC trajectory are not captured "
+                "yet — they need the variable registry (architecture doc "
+                "§2.3/§2.5), which is separate follow-up work, not part of "
+                "this snapshot format."
+            ),
+        }
+    except Exception:
+        logger.exception("Kon solve-resultaat niet opbouwen")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# RecordingIO
+# ---------------------------------------------------------------------------
+
+
+class RecordingIO:
+    """Passthrough + record. Every patched call still goes to the real
+    implementation and returns the real result unmodified — recording must
+    never change what a run does or computes (only ``ReplayIO`` suppresses
+    or fakes anything) — *unless* ``debug=True`` is passed, which is an
+    explicit, opt-in departure from that rule for exactly one purpose: so
+    capturing repeatedly while iterating on this tooling doesn't keep
+    pushing real settings to a real battery/EV/HA setup. It mirrors
+    day_ahead.py's own `calc_optimum_met_debug()` (``self.debug = True``
+    before solving, which gates most writes) plus, on top of that, the
+    same write-primitive no-ops ``ReplayIO`` always applies — because
+    `self.debug` alone does *not* gate everything: `self.notify(...)` and
+    one `set_value(entity_avg_temp, ...)` call are unconditional regardless
+    of the flag (architecture doc §1.2). Reads still happen for real and
+    are still captured; only the write side is suppressed.
+
+    ``png`` is a separate switch, independent of ``debug``: day_ahead.py
+    writes a chart PNG unconditionally regardless of ``self.debug``, and
+    it's a plain local file (no HA/DB involved), so whether to write it
+    isn't tied to whether writes elsewhere are suppressed. Defaults to
+    ``False`` — off by default, since most capture runs don't need one and
+    it's one more file per run — pass ``png=True`` to keep it.
+
+    On exit, writes a snapshot fixture capturing everything read,
+    best-effort: a capture failure is logged and swallowed, never allowed
+    to turn a successful production run into a failed one."""
+
+    # Zet alle capture-buffers en instellingen klaar vóórdat er iets gepatcht wordt.
+    def __init__(
+        self,
+        out_dir: str | Path = "../data/debug_snapshots",
+        *,
+        label: str = None,
+        debug: bool = False,
+        png: bool = False,
+    ):
+        self.out_dir = Path(out_dir)
+        self.label = label
+        self._debug = debug
+        self._png = png
+        self._patches = _PatchList()
+        self._primary = None  # first DaBase-family instance constructed
+        self._price_data: Optional[pd.DataFrame] = None
+        self._price_data_args: Optional[dict] = None
+        self._prog_data: Optional[pd.DataFrame] = None
+        self._ha_states: dict[str, str] = {}
+        self._baseload: dict[str, list] = {}
+        self._heatpump_run_hours: dict[str, float] = {}
+        self._solar_predictions: dict[str, pd.DataFrame] = {}
+        self._captured_at = dt.datetime.now()
+        self._model = None  # last mip.Model.optimize() was called on
+        self._cbc_log_chunks: list[str] = []
+        self.snapshot_path: Optional[Path] = None
+        self.result_path: Optional[Path] = None
+
+    # -- context manager -----------------------------------------------
+
+    # Installeert de patches bij het binnengaan van de with-blok.
+    def __enter__(self) -> "RecordingIO":
+        self._install_patches()
+        return self
+
+    # Schrijft de snapshot (best effort) en herstelt daarna altijd de patches, ook als het schrijven zelf mislukt.
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        try:
+            self._write_snapshot(exc)
+        except Exception:
+            logger.exception(
+                "Snapshot capture mislukt; de berekening zelf is hierdoor niet beïnvloed"
+            )
+        finally:
+            self._patches.restore()
+        return False  # never suppress the real run's own exception
+
+    # -- patch installation ----------------------------------------------
+
+    # Zet alle class- en module-patches voor deze opnamesessie neer; dekt samen alle kanalen uit sectie 1 van het ontwerp.
+    def _install_patches(self) -> None:
+        DaBase, Report, DBmanagerObj, SolarPredictor, _da_base_module = _import_targets()
+
+        original_init = DaBase.__init__
+
+        # Onthoudt de eerst geconstrueerde DaBase-instantie en zet, alleen bij debug-capture, self.debug en de write-onderdrukking aan.
+        def _wrapped_init(instance, *args, **kwargs):
+            original_init(instance, *args, **kwargs)
+            if instance.config is not None:
+                if self._debug:
+                    instance.debug = True
+                if self._primary is None:
+                    self._primary = instance
+
+        self._patches.set(DaBase, "__init__", _wrapped_init)
+
+        if self._debug:
+            label = f"RecordingIO(debug, {self.out_dir})"
+            self._patches.set(DaBase, "set_value", _make_noop_set_value(label))
+            self._patches.set(DaBase, "call_service", _make_noop_call_service(label))
+
+        # Independent of --debug: day_ahead.py writes a PNG chart
+        # unconditionally, regardless of self.debug. Off by default here —
+        # a capture/replay session usually doesn't need one and it's one
+        # more file cluttering ../data/images per run — but it's a plain
+        # local file write with no HA/DB implications, so turning it on
+        # doesn't need debug mode too.
+        if not self._png:
+            import matplotlib.pyplot as plt
+
+            self._patches.set(
+                plt, "savefig", _make_noop_savefig(f"RecordingIO({self.out_dir})")
+            )
+
+        original_get_state = DaBase.get_state
+
+        # Roept de echte get_state aan en legt de teruggegeven state vast onder de entity-id.
+        def _wrapped_get_state(instance, entity_id, *args, **kwargs):
+            result = original_get_state(instance, entity_id, *args, **kwargs)
+            try:
+                self._ha_states[entity_id] = result.state
+            except AttributeError:
+                pass
+            return result
+
+        self._patches.set(DaBase, "get_state", _wrapped_get_state)
+
+        original_baseload = DaBase.get_calculated_baseload
+
+        # Roept de echte baseload-opzoeking aan en onthoudt het resultaat per weekdag.
+        def _wrapped_baseload(instance, weekday, *args, **kwargs):
+            result = original_baseload(weekday, *args, **kwargs)
+            self._baseload[str(int(weekday))] = result
+            return result
+
+        self._patches.set(DaBase, "get_calculated_baseload", _wrapped_baseload)
+
+        original_get_price_data = Report.get_price_data
+
+        # Roept Report.get_price_data echt aan en bewaart het teruggegeven DataFrame.
+        def _wrapped_get_price_data(instance, start, end=None, interval="1hour"):
+            result = original_get_price_data(instance, start, end=end, interval=interval)
+            self._price_data = result
+            self._price_data_args = {
+                "start": str(start),
+                "end": str(end),
+                "interval": interval,
+            }
+            return result
+
+        self._patches.set(Report, "get_price_data", _wrapped_get_price_data)
+
+        original_hp_hours = Report.get_heatpump_run_hours
+
+        # Roept get_heatpump_run_hours echt aan en onthoudt het resultaat per argumentcombinatie.
+        def _wrapped_hp_hours(instance, *args, **kwargs):
+            result = original_hp_hours(instance, *args, **kwargs)
+            self._heatpump_run_hours[_call_key(args, kwargs)] = result
+            return result
+
+        self._patches.set(Report, "get_heatpump_run_hours", _wrapped_hp_hours)
+
+        original_get_prognose_data = DBmanagerObj.get_prognose_data
+
+        # Roept de echte prognosedata-query aan en bewaart het resultaat.
+        def _wrapped_get_prognose_data(instance, start=None, end=None, interval="1hour"):
+            result = original_get_prognose_data(instance, start=start, end=end, interval=interval)
+            self._prog_data = result
+            return result
+
+        self._patches.set(DBmanagerObj, "get_prognose_data", _wrapped_get_prognose_data)
+
+        # Not in the original input cut-set (architecture doc §1): found by
+        # actually running a real config with a solar device configured for
+        # ML prediction. calc_optimum() -> DaBase.calc_solar_predictions()
+        # -> SolarPredictor.predict_solar_device() does its own DB reads
+        # (get_time_border_record, get_column_data) that DBmanagerObj's
+        # patch above never sees, because those calls only happen inside
+        # this method — patched wholesale, same principle as
+        # Report.get_price_data, rather than trying to fake the two
+        # DB primitives generically.
+        original_predict_solar_device = SolarPredictor.predict_solar_device
+
+        # Roept de echte ML-zonnevoorspelling aan en bewaart het resultaat per paneelnaam, niet per tijdvenster, want dat laatste kan meer drift geven dan bedoeld.
+        def _wrapped_predict_solar_device(instance, solar_option, start, end):
+            result = original_predict_solar_device(instance, solar_option, start, end)
+            # Keyed by device name only, not (start, end): those two are
+            # themselves derived from calc_optimum()'s own internal
+            # dt.datetime.now() call, which fires strictly later than (and
+            # therefore can drift from) RecordingIO's own captured_at
+            # timestamp — a live run's DB/HA setup alone can take long
+            # enough to cross an interval boundary between the two. There
+            # is only ever one legitimate (start, end) window per device
+            # per snapshot anyway, so the name alone is both sufficient
+            # and immune to that drift. Found by an actual capture/replay
+            # round trip against a live config, not by reasoning about it.
+            key = _call_key((getattr(solar_option, "name", None),), {})
+            self._solar_predictions[key] = result
+            return result
+
+        self._patches.set(SolarPredictor, "predict_solar_device", _wrapped_predict_solar_device)
+
+        # Re-anchor _captured_at to the moment calc_optimum() is actually
+        # invoked, not construction time. The __init__ default (set before
+        # DaCalc()'s own real DB/HA setup even starts) is exactly the gap
+        # that produced the solar_predictions key drift above — the more
+        # of that setup elapses before the timestamp is taken, the further
+        # meta.captured_at (and hence the frozen replay clock) drifts from
+        # what calc_optimum()'s own internal `dt.datetime.now()` actually
+        # returns a few lines into the real method. This patch narrows that
+        # gap to essentially the wrapper call overhead.
+        try:
+            from dao.prog.day_ahead import DaCalc
+            import dao.prog.day_ahead as day_ahead_module
+
+            original_calc_optimum = DaCalc.calc_optimum
+
+            # Zet captured_at pas op het moment dat calc_optimum() echt start in plaats van bij constructie, om klokdrift tussen opname en replay te beperken.
+            def _wrapped_calc_optimum(instance, *args, **kwargs):
+                self._captured_at = dt.datetime.now()
+                return original_calc_optimum(instance, *args, **kwargs)
+
+            self._patches.set(DaCalc, "calc_optimum", _wrapped_calc_optimum)
+            _install_cbc_log_capture(self._patches, day_ahead_module, self)
+        except ImportError:
+            logger.warning(
+                "RecordingIO: kon day_ahead niet importeren; captured_at "
+                "blijft op het constructie-tijdstip staan en het CBC-log "
+                "wordt niet vastgelegd"
+            )
+
+        _install_model_capture(self._patches, self)
+
+    # -- snapshot writing --------------------------------------------------
+
+    # Bouwt en schrijft het snapshot-bestand met alle vastgelegde kanalen, inclusief de geheimencontrole vlak vóór het schrijven.
+    def _write_snapshot(self, exc: Optional[BaseException]) -> None:
+        if self._primary is None:
+            logger.warning(
+                "RecordingIO: geen DaBase-instantie geconstrueerd binnen de "
+                "context; er is niets om vast te leggen"
+            )
+            return
+
+        sanitized_config = _sanitize_config(self._primary.config)
+        secret_values = list(
+            (getattr(self._primary, "loader", None) or _FakeLoader()).secrets.values()
+        )
+
+        meta = {
+            "schema_version": SCHEMA_VERSION,
+            "schema_min_supported": SCHEMA_MIN_SUPPORTED,
+            "captured_at": self._captured_at.isoformat(),
+            "interval": getattr(self._primary, "interval", None),
+            "solver_threads": getattr(self._primary, "_solver_threads", -1),
+            "strategy": getattr(self._primary, "strategy", None),
+            "dao_version": _dao_version(),
+            "git_sha": _git_sha(),
+            "mip_version": getattr(mip, "__version__", None) if mip else None,
+            "python_version": sys.version.split()[0],
+            "config_hash": _config_hash(sanitized_config),
+            "file_name": getattr(self._primary, "file_name", None),
+            "exception": f"{type(exc).__name__}: {exc}" if exc is not None else None,
+        }
+
+        ha_context = None
+        if getattr(self._primary, "ha_context", None) is not None:
+            hc = self._primary.ha_context
+            ha_context = {
+                "latitude": hc.latitude,
+                "longitude": hc.longitude,
+                "time_zone": hc.time_zone,
+                "country": hc.country,
+            }
+
+        snapshot = {
+            "meta": meta,
+            "ha_context": ha_context,
+            "price_data": _dataframe_to_payload(self._price_data)
+            if self._price_data is not None
+            else None,
+            "price_data_args": self._price_data_args,
+            "prog_data": _dataframe_to_payload(self._prog_data)
+            if self._prog_data is not None
+            else None,
+            "ha_states": self._ha_states,
+            "baseload": self._baseload,
+            "heatpump_run_hours": self._heatpump_run_hours,
+            "solar_predictions": {
+                key: _dataframe_to_payload(df) for key, df in self._solar_predictions.items()
+            },
+            "config": sanitized_config,
+        }
+
+        blob = json.dumps(snapshot, default=str)
+        _assert_no_secret_leak(blob, secret_values)
+
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        stamp = self._captured_at.strftime("%Y-%m-%dT%H%M")
+        suffix = f"_{self.label}" if self.label else ""
+        base_name = f"calc_{stamp}{suffix}"
+        self.snapshot_path = self.out_dir / f"{base_name}.json"
+        with open(self.snapshot_path, "w", encoding="utf-8") as f:
+            f.write(blob)
+        logger.info("Debug snapshot geschreven: %s", self.snapshot_path)
+
+        self._write_result(base_name)
+
+    # Schrijft het bijbehorende *.result.json, alleen als er ook daadwerkelijk gesolved is.
+    def _write_result(self, base_name: str) -> None:
+        result = _build_result_dict(
+            self._model,
+            self._cbc_log_chunks,
+            {"captured_at": self._captured_at.isoformat()},
+        )
+        if result is None:
+            return
+        self.result_path = self.out_dir / f"{base_name}.result.json"
+        with open(self.result_path, "w", encoding="utf-8") as f:
+            json.dump(result, f, default=str)
+        logger.info("Debug result geschreven: %s", self.result_path)
+
+
+# Leest de addon-versie uit dao/prog/version.py, nodig om een snapshot te kunnen koppelen aan de code die hem produceerde.
+def _dao_version() -> Optional[str]:
+    try:
+        from dao.prog.version import __version__
+
+        return __version__
+    except Exception:
+        return None
+
+
+# Leest de huidige git-commit als optioneel extra herkenningspunt voor ontwikkelbuilds.
+def _git_sha() -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=Path(__file__).resolve().parent,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip() or None
+    except Exception:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# ReplayIO
+# ---------------------------------------------------------------------------
+
+
+class ReplayIO:
+    """Serves every input channel from a loaded snapshot and suppresses
+    every write primitive, so a ``DaCalc(...).calc_optimum()`` run inside
+    this context needs no Home Assistant and no database connection, and
+    writes nothing back to either. Any input not present in the snapshot
+    raises ``SnapshotMiss`` naming what was missing, rather than silently
+    falling back to a default or to live state. The one exception is the
+    chart PNG, gated separately by ``png`` (default ``False``, since it's
+    a plain local file with no HA/DB implications) rather than folded into
+    the always-on write suppression."""
+
+    # Laadt de snapshot, controleert schemaversie en dao-versie, en zet alle read-only databronnen klaar voor gebruik tijdens replay.
+    def __init__(
+        self,
+        snapshot: str | Path | dict,
+        *,
+        solver_threads: Optional[int] = None,
+        png: bool = False,
+    ):
+        """``solver_threads=None`` (the default) replays with the same
+        thread count the captured run itself used (``meta.solver_threads``,
+        normally ``-1`` — all cores, same as any ordinary day_ahead.py run),
+        so solve time stays representative of a real run and isn't
+        dominated by single-threaded CBC's much slower search. Single-
+        threaded CBC is also not just slower: found by comparing an actual
+        capture/replay pair, it can genuinely fail to reach the same
+        objective within day_ahead.py's fixed `model.max_nodes = 1500` —
+        multi-threaded CBC explores far more of the tree per second of
+        wall time, so the same node budget buys much less search with one
+        thread. That makes forcing threads=1 unconditionally actively
+        misleading for "is this still fast / did the answer change"
+        checks, which is the common case.
+
+        Pass an explicit ``solver_threads`` value to override — ``1`` for
+        bit-for-bit reproducibility (accepting the slower, possibly
+        node-capped solve as the price of eliminating multi-threaded CBC's
+        branching nondeterminism), or any other count to see how the solve
+        behaves at that thread count, e.g. to compare against the captured
+        run's own timing."""
+        self._solver_threads_override = solver_threads
+        self._png = png
+        self._source = str(snapshot) if not isinstance(snapshot, dict) else "<dict>"
+        if isinstance(snapshot, dict):
+            self._snapshot = snapshot
+        else:
+            with open(snapshot, "r", encoding="utf-8") as f:
+                self._snapshot = json.load(f)
+        self._patches = _PatchList()
+        self._primary = None
+        self._reads: set[str] = set()
+        self._freeze = None  # freezegun handle, set in _install_patches
+        self._model = None  # last mip.Model.optimize() was called on
+        self._cbc_log_chunks: list[str] = []
+
+        meta = self._snapshot.get("meta", {})
+        self._recorded_solver_threads = meta.get("solver_threads", -1)
+        schema_version = meta.get("schema_version", 0)
+        if schema_version < SCHEMA_MIN_SUPPORTED:
+            raise SnapshotMiss(
+                f"ReplayIO: snapshot schema_version {schema_version} is older "
+                f"than the minimum supported ({SCHEMA_MIN_SUPPORTED}); "
+                f"this fixture predates the current snapshot format."
+            )
+        snapshot_version = meta.get("dao_version")
+        current_version = _dao_version()
+        if snapshot_version and current_version and snapshot_version != current_version:
+            logger.warning(
+                "ReplayIO: snapshot was captured with dao_version %s, "
+                "replaying with %s — results may not be comparable",
+                snapshot_version,
+                current_version,
+            )
+
+        self._price_data = (
+            _dataframe_from_payload(self._snapshot["price_data"])
+            if self._snapshot.get("price_data") is not None
+            else None
+        )
+        self._prog_data = (
+            _dataframe_from_payload(self._snapshot["prog_data"])
+            if self._snapshot.get("prog_data") is not None
+            else None
+        )
+        self._ha_states: dict[str, str] = self._snapshot.get("ha_states", {})
+        self._baseload: dict[str, list] = self._snapshot.get("baseload", {})
+        self._heatpump_run_hours: dict[str, float] = self._snapshot.get(
+            "heatpump_run_hours", {}
+        )
+        self._solar_predictions: dict[str, pd.DataFrame] = {
+            key: _dataframe_from_payload(payload)
+            for key, payload in self._snapshot.get("solar_predictions", {}).items()
+        }
+        self._ha_context = self._snapshot.get("ha_context")
+        self._config_dict = self._snapshot.get("config")
+
+    @property
+    # Geeft de entity's terug die tijdens de replay daadwerkelijk zijn opgevraagd, om een ongebruikte override op te kunnen sporen.
+    def reads(self) -> set[str]:
+        """Entity ids actually read via ``get_state`` during the replayed
+        run — lets a caller detect a scenario override nothing consulted
+        (architecture doc §8.3)."""
+        return set(self._reads)
+
+    @property
+    # Geeft de meta-sectie van de snapshot terug.
+    def meta(self) -> dict:
+        return dict(self._snapshot.get("meta", {}))
+
+    # Zet het opgeloste replaymodel om naar dezelfde vorm als een capture-resultaat, zodat replay-uitkomsten te diffen zijn tegen een capture of een andere replay.
+    def build_result(self) -> Optional[dict]:
+        """The replayed run's own objective/status/gap/cbc_log, in the same
+        shape as a capture's ``*.result.json`` — so it can be compared
+        against one with ``diff``, or against another replay run at a
+        different thread count. Returns ``None`` if the replay never
+        reached ``model.optimize()`` (e.g. it errored out on missing data
+        first). Must be called after the ``with`` block exits, or at least
+        after ``calc_optimum()`` returns — there's nothing to build before
+        that."""
+        threads_used = (
+            self._recorded_solver_threads
+            if self._solver_threads_override is None
+            else self._solver_threads_override
+        )
+        return _build_result_dict(
+            self._model,
+            self._cbc_log_chunks,
+            {
+                "replayed_at": dt.datetime.now().isoformat(),
+                "source_snapshot": self._source,
+                "solver_threads": threads_used,
+            },
+        )
+
+    # -- context manager -----------------------------------------------
+
+    # Installeert de patches bij het binnengaan van de with-blok.
+    def __enter__(self) -> "ReplayIO":
+        self._install_patches()
+        return self
+
+    # Stopt de bevroren klok en herstelt de patches bij het verlaten van de with-blok.
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if self._freeze is not None:
+            self._freeze.stop()
+            self._freeze = None
+        self._patches.restore()
+        return False
+
+    # -- patch installation ----------------------------------------------
+
+    # Zet alle class- en module-patches voor deze replaysessie neer: config, reads, writes en de klok.
+    def _install_patches(self) -> None:
+        DaBase, Report, DBmanagerObj, SolarPredictor, da_base_module = _import_targets()
+
+        if self._config_dict is None:
+            raise SnapshotMiss(
+                f"ReplayIO ({self._source}): snapshot has no 'config' field; "
+                f"cannot replay without a config to construct DaBase from."
+            )
+        rehydrated_config = _rehydrate_config(self._config_dict)
+        self._patches.set(DaBase, "_config", rehydrated_config)
+        self._patches.set(DaBase, "_loader", _FakeLoader())
+
+        # Same capture as RecordingIO, for the same reason: without this,
+        # a replay produces no *.result.json at all, so there is nothing
+        # to `diff` its objective/gap/status against — not the source
+        # capture, not another replay at a different thread count.
+        try:
+            import dao.prog.day_ahead as day_ahead_module
+
+            _install_cbc_log_capture(self._patches, day_ahead_module, self)
+        except ImportError:
+            logger.warning(
+                "ReplayIO: kon day_ahead niet importeren; het CBC-log "
+                "wordt niet vastgelegd"
+            )
+        _install_model_capture(self._patches, self)
+
+        original_init = DaBase.__init__
+
+        # Dwingt debug-modus en het gekozen aantal threads af op elke geconstrueerde instantie, ongeacht wie hem aanmaakt.
+        def _wrapped_init(instance, *args, **kwargs):
+            original_init(instance, *args, **kwargs)
+            if instance.config is not None:
+                instance.debug = True
+                instance._solver_threads = (
+                    self._recorded_solver_threads
+                    if self._solver_threads_override is None
+                    else self._solver_threads_override
+                )
+                if self._primary is None:
+                    self._primary = instance
+
+        self._patches.set(DaBase, "__init__", _wrapped_init)
+
+        # Levert de opgeslagen state terug en faalt hard als de gevraagde entity niet in de snapshot zit.
+        def _replay_get_state(instance, entity_id, *args, **kwargs):
+            self._reads.add(entity_id)
+            if entity_id not in self._ha_states:
+                raise SnapshotMiss(
+                    f"ReplayIO ({self._source}): entity '{entity_id}' is not "
+                    f"present in the snapshot's ha_states — either the "
+                    f"fixture is stale or a scenario override is missing."
+                )
+            return _FakeState(self._ha_states[entity_id])
+
+        self._patches.set(DaBase, "get_state", _replay_get_state)
+
+        # Levert de opgeslagen baseload terug voor de gevraagde weekdag en faalt hard als die ontbreekt.
+        def _replay_baseload(instance, weekday, *args, **kwargs):
+            key = str(int(weekday))
+            if key not in self._baseload:
+                raise SnapshotMiss(
+                    f"ReplayIO ({self._source}): baseload for weekday {key} "
+                    f"is not present in the snapshot."
+                )
+            return self._baseload[key]
+
+        self._patches.set(DaBase, "get_calculated_baseload", _replay_baseload)
+
+        # Levert de opgeslagen prijsdata terug in plaats van een databasequery uit te voeren.
+        def _replay_get_price_data(instance, start, end=None, interval="1hour"):
+            if self._price_data is None:
+                raise SnapshotMiss(
+                    f"ReplayIO ({self._source}): snapshot has no price_data."
+                )
+            return self._price_data.copy()
+
+        self._patches.set(Report, "get_price_data", _replay_get_price_data)
+
+        # Levert het opgeslagen resultaat terug per argumentcombinatie en faalt hard als die ontbreekt.
+        def _replay_hp_hours(instance, *args, **kwargs):
+            key = _call_key(args, kwargs)
+            if key not in self._heatpump_run_hours:
+                raise SnapshotMiss(
+                    f"ReplayIO ({self._source}): get_heatpump_run_hours"
+                    f"{tuple(args)} is not present in the snapshot "
+                    f"(looked up as key {key})."
+                )
+            return self._heatpump_run_hours[key]
+
+        self._patches.set(Report, "get_heatpump_run_hours", _replay_hp_hours)
+
+        # Levert de opgeslagen zonnevoorspelling terug op paneelnaam, ongevoelig voor een afwijkend tijdvenster.
+        def _replay_predict_solar_device(instance, solar_option, start, end):
+            # Keyed by device name only — see the matching comment on the
+            # RecordingIO side for why (start, end) is deliberately excluded.
+            key = _call_key((getattr(solar_option, "name", None),), {})
+            if key not in self._solar_predictions:
+                raise SnapshotMiss(
+                    f"ReplayIO ({self._source}): predict_solar_device for "
+                    f"{getattr(solar_option, 'name', '?')!r} is not present "
+                    f"in the snapshot (looked up as key {key})."
+                )
+            return self._solar_predictions[key].copy()
+
+        self._patches.set(SolarPredictor, "predict_solar_device", _replay_predict_solar_device)
+
+        fake_db = _FakeDbManager(self._prog_data, self._source)
+        self._patches.set(da_base_module, "make_db_da", lambda *a, **k: fake_db)
+        self._patches.set(da_base_module, "make_db_ha", lambda *a, **k: fake_db)
+
+        ha_context = self._ha_context or {
+            "latitude": 0.0,
+            "longitude": 0.0,
+            "time_zone": "UTC",
+            "country": "NL",
+        }
+        self._patches.set(
+            da_base_module, "get", lambda *a, **k: _FakeHttpResponse(ha_context)
+        )
+
+        # hass.Hass.__init__ (from the hassapi package DaBase subclasses)
+        # does its own independent reachability check via a bare
+        # `requests.get(...)` inside hassapi.client.base — a call site
+        # da_base.py has no seam for at all, distinct from the explicit
+        # `get(hassurl + "api/config")` above. Patching the `requests`
+        # module's own `get` attribute reaches it, since hassapi does
+        # `import requests` (a shared module reference) rather than
+        # `from requests import get` (a copied one, which is why da_base.py
+        # needed its own separate patch just above).
+        import requests
+
+        self._patches.set(
+            requests,
+            "get",
+            lambda *a, **k: _FakeHttpResponse({"message": "API running."}),
+        )
+
+        label = f"ReplayIO ({self._source})"
+        self._patches.set(DaBase, "set_value", _make_noop_set_value(label))
+        self._patches.set(DaBase, "call_service", _make_noop_call_service(label))
+
+        # Independent of the (always-on) HA write suppression above: the
+        # PNG is a plain local file, not an HA/DB write, so whether to
+        # keep it is its own switch. Off by default — see `png` on
+        # __init__.
+        if not self._png:
+            import matplotlib.pyplot as plt
+
+            self._patches.set(plt, "savefig", _make_noop_savefig(label))
+
+        try:
+            import freezegun
+
+            captured_at = self._snapshot.get("meta", {}).get("captured_at")
+            if captured_at:
+                # tick=True: the clock still starts anchored at captured_at
+                # (so calc_optimum()'s date/weekday-dependent reads land at
+                # the intended moment — replay's DB/HA reads are all faked,
+                # so there's no real setup latency to drift across an
+                # interval boundary before they fire), but it advances in
+                # real time from there rather than staying frozen solid.
+                # Without tick, freezegun also freezes time.perf_counter()/
+                # time.monotonic() — found by a user reporting "Rekentijd:
+                # 0.00 sec" on every replay, since day_ahead.py measures
+                # solve time with time.perf_counter(), and a fully static
+                # clock makes any two reads of it identical by construction.
+                self._freeze = freezegun.freeze_time(captured_at, tick=True)
+                self._freeze.start()
+        except ImportError:
+            logger.warning(
+                "ReplayIO: freezegun is niet beschikbaar; de wall-clock wordt "
+                "niet bevroren tijdens deze replay"
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI (A6, §13)
+# ---------------------------------------------------------------------------
+#
+# `python -m dao.prog.da_debug <command>` — run from anywhere the `dao`
+# package is importable from (typically the repository root); paths are
+# resolved absolutely from --data-dir at startup and never from cwd.
+
+EXIT_OK = 0
+EXIT_ASSERTION_FAILED = 1
+EXIT_USAGE = 2
+EXIT_SOLVER_FAILURE = 3
+EXIT_SNAPSHOT_MISS = 4
+EXIT_HERMETICITY_VIOLATION = 5
+
+
+class UsageError(Exception):
+    """A CLI-level usage problem: bad arguments, missing file, malformed
+    ``--state``. Distinct from ``SnapshotMiss`` (a fixture is missing data)
+    and ``HermeticityViolation`` (replay reached for the network) — each
+    maps to its own exit code in ``main()``."""
+
+
+class HermeticityViolation(RuntimeError):
+    """Raised when a replayed run reaches for the network while ``--offline``
+    (the default for ``replay``) is in effect. §13.2: this is what turns
+    "the operator happened to be on the right machine" into something the
+    tool itself proves on every run."""
+
+
+# Geeft de map van dit bestand terug, basis voor alle padresolutie zonder afhankelijkheid van de werkmap.
+def _module_dir() -> Path:
+    return Path(__file__).resolve().parent
+
+
+# Zet dao/prog op sys.path zodat day_ahead.py's eigen kale import van utils blijft werken, ook wanneer dit bestand als module wordt aangeroepen.
+def _ensure_day_ahead_importable() -> None:
+    """day_ahead.py does `from utils import (...)` — a bare import that only
+    resolves when dao/prog itself is on sys.path. That's true when it's run
+    as a script from that directory (the addon's own invocation style), but
+    not when it's reached via the dotted `dao.prog.day_ahead` import this
+    CLI uses when invoked as `python -m dao.prog.da_debug` from elsewhere.
+    Found by actually running `replay` from the repo root, not by reading
+    the import — exactly the class of gap static reading misses."""
+    module_dir = str(_module_dir())
+    if module_dir not in sys.path:
+        sys.path.append(module_dir)
+
+
+# Standaard datamap, gelijk aan de ../data-conventie die day_ahead.py zelf ook gebruikt.
+def _default_data_dir() -> Path:
+    return (_module_dir() / ".." / "data").resolve()
+
+
+# Kiest --data-dir als die is opgegeven, anders de standaardmap.
+def _resolve_data_dir(args: argparse.Namespace) -> Path:
+    if getattr(args, "data_dir", None):
+        return Path(args.data_dir).resolve()
+    return _default_data_dir()
+
+
+# Zoekt een snapshotbestand op: een pad met map laat het met rust, een kale bestandsnaam wordt tegen debug_snapshots/ geresolved.
+def _resolve_snapshot_arg(data_dir: Path, given: str) -> Path:
+    """A bare filename resolves against ``<data-dir>/debug_snapshots/``;
+    anything that already exists, is absolute, or has path separators is
+    used as given."""
+    p = Path(given)
+    if p.exists() or p.is_absolute() or len(p.parts) > 1:
+        return p.resolve()
+    return (data_dir / "debug_snapshots" / given).resolve()
+
+
+# Leest en parseert een snapshot-JSON-bestand, met een duidelijke fout als het niet bestaat.
+def _load_snapshot_file(path: Path) -> dict:
+    if not path.exists():
+        raise UsageError(f"Snapshot not found: {path}")
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+# Kiest op één plek tussen JSON- en tekstuitvoer, zodat elk commando dezelfde --json-afhandeling deelt.
+def _emit(args: argparse.Namespace, data: dict, render) -> None:
+    if getattr(args, "json", False):
+        print(json.dumps(data, indent=2, default=str, sort_keys=True))
+    else:
+        render(data)
+
+
+# Geeft een korte 'rijenxkolommen'-samenvatting van een DataFrame-payload, voor gebruik in inspect.
+def _df_payload_shape(payload: Optional[dict]) -> str:
+    if not payload:
+        return "none"
+    try:
+        rows = len(json.loads(payload["data"]).get("data", []))
+        cols = len(payload.get("dtypes", {}))
+        return f"{rows}x{cols}"
+    except Exception:
+        return "unknown"
+
+
+# Telt hoeveel velden in een configboom als geheim zijn geredigeerd, voor een snelle controle in inspect.
+def _count_redacted(value: Any) -> int:
+    """Count REDACTED_SECRET markers anywhere in a sanitised config tree."""
+    if isinstance(value, str):
+        return 1 if value == REDACTED_SECRET else 0
+    if isinstance(value, dict):
+        return sum(_count_redacted(v) for v in value.values())
+    if isinstance(value, list):
+        return sum(_count_redacted(v) for v in value)
+    return 0
+
+
+# Doorloopt een gerehydrateerde config en meldt elk SecretStr-veld dat niet de redactiemarkering bevat; kern van verify's geheimencontrole.
+def _find_unredacted_secrets(value: Any, path: str = "") -> list[str]:
+    """Walk a *rehydrated* (live pydantic object graph, not a dict) config
+    and report the dotted path of every SecretStr field that is not exactly
+    REDACTED_SECRET — i.e. a real or planted credential. Mirrors
+    ``_sanitize_config_value``'s traversal but checks rather than redacts."""
+    from dao.prog.config.models.base import SecretStr
+    from pydantic import BaseModel
+
+    found: list[str] = []
+    if isinstance(value, SecretStr):
+        if str(value) != REDACTED_SECRET:
+            found.append(path or "<root>")
+        return found
+    if isinstance(value, BaseModel):
+        for name in type(value).model_fields:
+            child = f"{path}.{name}" if path else name
+            found.extend(_find_unredacted_secrets(getattr(value, name), child))
+        return found
+    if isinstance(value, dict):
+        for k, v in value.items():
+            child = f"{path}.{k}" if path else str(k)
+            found.extend(_find_unredacted_secrets(v, child))
+        return found
+    if isinstance(value, (list, tuple)):
+        for i, v in enumerate(value):
+            found.extend(_find_unredacted_secrets(v, f"{path}[{i}]"))
+        return found
+    return found
+
+
+# Laadt een live options.json via een wegwerpkopie (nooit het origineel) en vergelijkt de confighash met die van de snapshot.
+def _check_config_drift(config_path_str: str, stored_hash: Optional[str]) -> dict:
+    """§13.4: copy-then-load. Never opens the real config file for writing,
+    and asserts (not just assumes) that it comes out byte-identical."""
+    import shutil
+    import tempfile
+
+    config_path = Path(config_path_str).resolve()
+    if not config_path.exists():
+        raise UsageError(f"Config not found: {config_path}")
+    secrets_path = config_path.parent / "secrets.json"
+
+    before_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_config = Path(tmp) / config_path.name
+        shutil.copy2(config_path, tmp_config)
+        if secrets_path.exists():
+            shutil.copy2(secrets_path, Path(tmp) / "secrets.json")
+
+        from dao.prog.config.loader import ConfigurationLoader
+
+        loader = ConfigurationLoader(tmp_config)
+        live_config = loader.load_and_validate()
+        live_hash = _config_hash(_sanitize_config(live_config))
+
+    after_hash = hashlib.sha256(config_path.read_bytes()).hexdigest()
+    if before_hash != after_hash:
+        # Should be structurally impossible — we only ever load the temp
+        # copy — so this is an assertion, not a warning.
+        raise RuntimeError(
+            f"BUG: {config_path} changed on disk during a supposedly "
+            f"copy-then-load verify pass"
+        )
+
+    return {
+        "live_config_hash": live_hash,
+        "differs": stored_hash is not None and live_hash != stored_hash,
+    }
+
+
+# Patcht socket.connect(_ex) zodat elk netwerkgebruik tijdens replay direct met een duidelijke fout stopt in plaats van stil te slagen.
+def _offline_guard():
+    """Patch socket.socket.connect/connect_ex to raise. Returns a handle
+    for _offline_unguard(). See HermeticityViolation."""
+    import socket
+
+    original_connect = socket.socket.connect
+    original_connect_ex = socket.socket.connect_ex
+
+    # Blokkeert een connect-poging en meldt welk adres erbij hoorde.
+    def _blocked_connect(self, address, *a, **k):
+        raise HermeticityViolation(
+            f"Network access blocked under --offline: "
+            f"socket.socket.connect({address!r})"
+        )
+
+    # Zelfde blokkade als _blocked_connect, voor de _ex-variant.
+    def _blocked_connect_ex(self, address, *a, **k):
+        raise HermeticityViolation(
+            f"Network access blocked under --offline: "
+            f"socket.socket.connect_ex({address!r})"
+        )
+
+    socket.socket.connect = _blocked_connect
+    socket.socket.connect_ex = _blocked_connect_ex
+    return socket, original_connect, original_connect_ex
+
+
+# Zet de originele socket-methodes terug na afloop van de replay.
+def _offline_unguard(saved) -> None:
+    socket_module, original_connect, original_connect_ex = saved
+    socket_module.socket.connect = original_connect
+    socket_module.socket.connect_ex = original_connect_ex
+
+
+# -- commands -----------------------------------------------------------
+
+
+# Voert een echte calc_optimum()-run uit binnen RecordingIO en schrijft de snapshot en het resultaat weg.
+def cmd_capture(args: argparse.Namespace, data_dir: Path) -> int:
+    config_path = Path(args.config).resolve() if args.config else data_dir / "options.json"
+    if not config_path.exists():
+        raise UsageError(f"Config not found: {config_path}")
+    out_dir = Path(args.out_dir).resolve() if args.out_dir else data_dir / "debug_snapshots"
+
+    _ensure_day_ahead_importable()
+    from dao.prog.day_ahead import DaCalc
+
+    kwargs = {}
+    if args.start_dt:
+        kwargs["_start_dt"] = dt.datetime.fromisoformat(args.start_dt)
+    if args.start_soc is not None:
+        kwargs["_start_soc"] = args.start_soc
+    if args.start_ev_soc is not None:
+        kwargs["_start_ev_soc"] = args.start_ev_soc
+
+    rec = RecordingIO(out_dir=out_dir, label=args.label, debug=args.debug, png=args.png)
+    error = None
+    result = None
+    with rec:
+        dacalc = DaCalc(str(config_path))
+        try:
+            result = dacalc.calc_optimum(**kwargs)
+        except Exception as ex:  # noqa: BLE001 - reported below, not swallowed
+            error = ex
+
+    data = {
+        "snapshot": str(rec.snapshot_path) if rec.snapshot_path else None,
+        "result": str(rec.result_path) if rec.result_path else None,
+        "error": f"{type(error).__name__}: {error}" if error is not None else None,
+        "debug": bool(args.debug),
+        "png": bool(args.png),
+    }
+
+    # Toont het capture-resultaat leesbaar op het scherm.
+    def render(d):
+        print(f"snapshot: {d['snapshot']}" if d["snapshot"] else "capture: nothing written (see log)")
+        if d["result"]:
+            print(f"result:   {d['result']}")
+        print(
+            f"debug:    {d['debug']}"
+            + ("" if d["debug"] else " (this run wrote real settings to HA/DB — pass --debug to suppress that)")
+        )
+        print(f"png:      {d['png']}" + ("" if d["png"] else " (pass --png to keep the chart)"))
+        if d["error"]:
+            print(f"error during calc_optimum(): {d['error']}")
+
+    _emit(args, data, render)
+
+    if error is not None or result is None:
+        return EXIT_SOLVER_FAILURE
+    return EXIT_OK
+
+
+# Speelt een snapshot hermetisch af binnen ReplayIO en schrijft het replay-resultaat weg.
+def cmd_replay(args: argparse.Namespace, data_dir: Path) -> int:
+    snapshot_path = _resolve_snapshot_arg(data_dir, args.snapshot)
+    if not snapshot_path.exists():
+        raise UsageError(f"Snapshot not found: {snapshot_path}")
+
+    _ensure_day_ahead_importable()
+    from dao.prog.day_ahead import DaCalc
+
+    guard = _offline_guard() if args.offline else None
+    result = None
+    try:
+        with ReplayIO(snapshot_path, solver_threads=args.threads, png=args.png) as replay:
+            file_name = str(snapshot_path)
+            dacalc = DaCalc(file_name)
+            result = dacalc.calc_optimum()
+        reads = sorted(replay.reads)
+        result_dict = replay.build_result()
+    finally:
+        if guard is not None:
+            _offline_unguard(guard)
+
+    result_path = None
+    if result_dict is not None:
+        if args.out_result:
+            result_path = Path(args.out_result).resolve()
+        else:
+            result_path = snapshot_path.parent / (
+                f"{snapshot_path.stem}.replay-threads{args.threads}.result.json"
+            )
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(result_path, "w", encoding="utf-8") as f:
+            json.dump(result_dict, f, default=str)
+
+    data = {
+        "snapshot": str(snapshot_path),
+        "result": str(result_path) if result_path else None,
+        "reads": reads,
+        "offline": bool(args.offline),
+        "threads": args.threads,
+        "png": bool(args.png),
+    }
+
+    # Toont het replay-resultaat leesbaar op het scherm.
+    def render(d):
+        print(f"replayed: {d['snapshot']}")
+        print(f"offline:  {d['offline']}")
+        print(f"threads:  {d['threads']}" + (" (all cores — pass --threads 1 for reproducibility)" if d["threads"] == -1 else ""))
+        print(f"png:      {d['png']}" + ("" if d["png"] else " (pass --png to keep the chart)"))
+        print(f"entities read: {len(d['reads'])}")
+        print(f"result:   {d['result']}" if d["result"] else "result:   not written (solve never reached model.optimize())")
+
+    _emit(args, data, render)
+    return EXIT_OK if result is not None else EXIT_SOLVER_FAILURE
+
+
+# Toont een samenvatting van een snapshot en eventueel resultaat, zonder de solver te draaien.
+def cmd_inspect(args: argparse.Namespace, data_dir: Path) -> int:
+    snapshot_path = _resolve_snapshot_arg(data_dir, args.snapshot)
+    snapshot = _load_snapshot_file(snapshot_path)
+    meta = snapshot.get("meta", {})
+
+    result_path = snapshot_path.parent / (snapshot_path.stem + ".result.json")
+    result = None
+    if result_path.exists():
+        with open(result_path, "r", encoding="utf-8") as f:
+            result = json.load(f)
+
+    data = {
+        "path": str(snapshot_path),
+        "meta": meta,
+        "ha_states_count": len(snapshot.get("ha_states", {})),
+        "price_data_shape": _df_payload_shape(snapshot.get("price_data")),
+        "prog_data_shape": _df_payload_shape(snapshot.get("prog_data")),
+        "baseload_days": len(snapshot.get("baseload", {})),
+        "heatpump_run_hours_count": len(snapshot.get("heatpump_run_hours", {})),
+        "secrets_redacted": _count_redacted(snapshot.get("config") or {}),
+        "result": result,
+    }
+
+    # Formatteert de samenvatting voor tekstweergave.
+    def render(d):
+        m = d["meta"]
+        print(f"dao {m.get('dao_version')} | mip {m.get('mip_version')} | schema {m.get('schema_version')}")
+        print(f"captured  {m.get('captured_at')}   interval {m.get('interval')}   strategy {m.get('strategy')}")
+        print(
+            f"ha_states {d['ha_states_count']} entities | "
+            f"price_data {d['price_data_shape']} | "
+            f"prog_data {d['prog_data_shape']} | "
+            f"baseload {d['baseload_days']} day(s) | "
+            f"hp_run_hours {d['heatpump_run_hours_count']}"
+        )
+        print(f"config    secrets: {d['secrets_redacted']} redacted")
+        if d["result"]:
+            r = d["result"]
+            print(
+                f"result    objective {r.get('objective_value')}  "
+                f"status {r.get('status')}  gap {r.get('gap')}"
+            )
+            cbc_log = r.get("cbc_log")
+            if cbc_log:
+                lines = cbc_log.count("\n") + 1
+                partial = "Exiting on maximum nodes" in cbc_log
+                flag = " — PARTIAL SEARCH, node cap hit, not proven optimal" if partial else ""
+                print(f"cbc_log   {lines} lines captured{flag} (full text in the .result.json)")
+            else:
+                print("cbc_log   not captured (older snapshot, or model.optimize() never ran)")
+        else:
+            print("result    (no .result.json next to this snapshot)")
+
+    _emit(args, data, render)
+    return EXIT_OK
+
+
+# Controleert schemaversie, confighash, geheimenlekken en optioneel configdrift; de integriteitscheck voor een snapshot.
+def cmd_verify(args: argparse.Namespace, data_dir: Path) -> int:
+    snapshot_path = _resolve_snapshot_arg(data_dir, args.snapshot)
+    snapshot = _load_snapshot_file(snapshot_path)
+    meta = snapshot.get("meta", {})
+    problems: list[str] = []
+
+    schema_version = meta.get("schema_version", 0)
+    if schema_version < SCHEMA_MIN_SUPPORTED:
+        problems.append(
+            f"schema_version {schema_version} is older than minimum "
+            f"supported {SCHEMA_MIN_SUPPORTED}"
+        )
+
+    config = snapshot.get("config")
+    if config is None:
+        problems.append("snapshot has no 'config' field")
+    else:
+        try:
+            rehydrated = _rehydrate_config(config)
+        except Exception as ex:
+            problems.append(f"config does not reconstruct: {ex}")
+            rehydrated = None
+        if rehydrated is not None:
+            leaked_fields = _find_unredacted_secrets(rehydrated)
+            if leaked_fields:
+                problems.append(
+                    f"{len(leaked_fields)} SecretStr field(s) not redacted: "
+                    f"{', '.join(leaked_fields)}"
+                )
+            recomputed_hash = _config_hash(_sanitize_config(rehydrated))
+            stored_hash = meta.get("config_hash")
+            if stored_hash and recomputed_hash != stored_hash:
+                problems.append(
+                    f"config_hash mismatch: stored {stored_hash}, "
+                    f"recomputed {recomputed_hash} (snapshot may have been "
+                    f"hand-edited)"
+                )
+
+    if args.secrets:
+        secrets_path = Path(args.secrets).resolve()
+        if not secrets_path.exists():
+            raise UsageError(f"Secrets file not found: {secrets_path}")
+        with open(secrets_path, "r", encoding="utf-8") as f:
+            secret_values = list(json.load(f).values())
+        blob = json.dumps(snapshot, default=str)
+        leaked_values = [v for v in secret_values if v and v in blob]
+        if leaked_values:
+            problems.append(
+                f"{len(leaked_values)} value(s) from {secrets_path} appear "
+                f"literally in the snapshot"
+            )
+
+    drift = None
+    if args.config:
+        drift = _check_config_drift(args.config, meta.get("config_hash"))
+        if drift.get("differs"):
+            problems.append(
+                f"live config at {args.config} has drifted from this "
+                f"snapshot's config (hash differs)"
+            )
+
+    data = {"path": str(snapshot_path), "ok": not problems, "problems": problems, "config_drift": drift}
+
+    # Toont OK of FAILED plus de gevonden problemen.
+    def render(d):
+        print(("OK: " if d["ok"] else "FAILED: ") + d["path"])
+        for p in d["problems"]:
+            print(f"  - {p}")
+
+    _emit(args, data, render)
+    return EXIT_OK if not problems else EXIT_ASSERTION_FAILED
+
+
+# Vergelijkt twee snapshots of twee resultaatbestanden en toont precies welke velden verschillen.
+def cmd_diff(args: argparse.Namespace, data_dir: Path) -> int:
+    first_path = _resolve_snapshot_arg(data_dir, args.first)
+    second_path = _resolve_snapshot_arg(data_dir, args.second)
+    first = _load_snapshot_file(first_path)
+    second = _load_snapshot_file(second_path)
+
+    is_result = "objective_value" in first and "objective_value" in second
+    changes: dict = {}
+
+    if is_result:
+        # Nested under "fields" (not merged flat into `changes`) so this
+        # branch produces the same two-level {section: {field: {first,
+        # second}}} shape the snapshot branch below does — render() below
+        # relies on that uniformity. Never actually exercised until now:
+        # every prior test compared a result file to itself, which
+        # short-circuits on the empty-changes path before render() ever
+        # walks a real entry.
+        field_changes = {
+            key: {"first": first.get(key), "second": second.get(key)}
+            for key in ("objective_value", "objective_bound", "status", "gap", "num_solutions")
+            if first.get(key) != second.get(key)
+        }
+        if field_changes:
+            changes["fields"] = field_changes
+    else:
+        first_states = first.get("ha_states", {})
+        second_states = second.get("ha_states", {})
+        state_changes = {
+            key: {"first": first_states.get(key), "second": second_states.get(key)}
+            for key in sorted(set(first_states) | set(second_states))
+            if first_states.get(key) != second_states.get(key)
+        }
+        if state_changes:
+            changes["ha_states"] = state_changes
+
+        first_meta = first.get("meta", {})
+        second_meta = second.get("meta", {})
+        meta_changes = {
+            key: {"first": first_meta.get(key), "second": second_meta.get(key)}
+            for key in sorted(set(first_meta) | set(second_meta))
+            if first_meta.get(key) != second_meta.get(key)
+        }
+        if meta_changes:
+            changes["meta"] = meta_changes
+
+    data = {
+        "first": str(first_path),
+        "second": str(second_path),
+        "kind": "result" if is_result else "snapshot",
+        "changes": changes,
+    }
+
+    # Toont de gevonden verschillen per sectie.
+    def render(d):
+        if not d["changes"]:
+            print("no differences")
+            return
+        for section, section_changes in d["changes"].items():
+            print(f"{section}:")
+            for k, v in section_changes.items():
+                print(f"  {k}: {v['first']!r} -> {v['second']!r}")
+
+    _emit(args, data, render)
+    return EXIT_OK
+
+
+# Maakt een nieuwe snapshot met overschreven entity-waarden, zonder de solver te draaien.
+def cmd_set(args: argparse.Namespace, data_dir: Path) -> int:
+    if not args.state:
+        raise UsageError("set requires at least one --state entity_id=value")
+    source_path = _resolve_snapshot_arg(data_dir, args.snapshot)
+    snapshot = _load_snapshot_file(source_path)
+
+    ha_states = dict(snapshot.get("ha_states", {}))
+    applied = {}
+    for item in args.state:
+        if "=" not in item:
+            raise UsageError(f"--state must be entity_id=value, got: {item!r}")
+        entity_id, value = item.split("=", 1)
+        ha_states[entity_id] = value
+        applied[entity_id] = value
+    snapshot["ha_states"] = ha_states
+
+    meta = dict(snapshot.get("meta", {}))
+    meta["derived_from"] = str(source_path)
+    meta["derived_overrides"] = applied
+    snapshot["meta"] = meta
+
+    out_path = Path(args.out).resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(snapshot, f, default=str)
+
+    data = {"out": str(out_path), "applied": applied}
+
+    # Toont welke waarden zijn toegepast.
+    def render(d):
+        print(f"wrote: {d['out']}")
+        for k, v in d["applied"].items():
+            print(f"  {k} = {v}")
+
+    _emit(args, data, render)
+    return EXIT_OK
+
+
+# Stub: dump_interval bestaat nog niet, dit commando geeft een duidelijke melding in plaats van te crashen.
+def cmd_dump(args: argparse.Namespace, data_dir: Path) -> int:
+    message = (
+        "dump is not implemented yet: it needs the variable registry "
+        "(architecture doc §2.3/§2.5), which is separate follow-up work "
+        "(A3), not part of this session."
+    )
+    data = {"error": message}
+    _emit(args, data, lambda d: print(d["error"]))
+    return EXIT_USAGE
+
+
+# Interne zelftest voor precies het scenario dat DaBase.get_state raakt: een geërfde, niet-eigen methode moet na restore weer via de klasse-hiërarchie lopen.
+def _patch_list_restore_check() -> None:
+    """The scenario that matters most: an attribute inherited via MRO
+    (never owned by the class itself, like DaBase.get_state on hass.Hass)
+    must be un-shadowed by delattr, not overwritten with a stale value."""
+
+    class Base:
+        # Triviale testmethode zonder eigen betekenis, alleen om patch en restore op te kunnen testen.
+        def greet(self):
+            return "base"
+
+    class Owner(Base):
+        pass
+
+    patches = _PatchList()
+    patches.set(Owner, "greet", lambda self: "patched")
+    if Owner().greet() != "patched":
+        raise AssertionError("patch did not apply")
+    patches.restore()
+    if "greet" in vars(Owner):
+        raise AssertionError("inherited attribute was not correctly un-shadowed")
+    if Owner().greet() != "base":
+        raise AssertionError("patch did not restore correctly")
+
+
+# Draait alle offline zelftests van da_debug.py, zonder dat daar een live stack voor nodig is.
+def cmd_selftest(args: argparse.Namespace, data_dir: Path) -> int:
+    checks: list[dict] = []
+
+    # Voert één zelftest uit en registreert of die geslaagd of mislukt is.
+    def check(name, fn):
+        try:
+            fn()
+            checks.append({"name": name, "ok": True, "error": None})
+        except Exception as ex:  # noqa: BLE001 - reported, not raised
+            checks.append({"name": name, "ok": False, "error": str(ex)})
+
+    # Controleert dat een DataFrame exact wordt teruggelezen na _dataframe_to_payload gevolgd door _dataframe_from_payload.
+    def _dataframe_roundtrip():
+        df = pd.DataFrame(
+            {
+                "time": [dt.datetime(2026, 1, 1, 0, 0), dt.datetime(2026, 1, 1, 0, 15)],
+                "value": [1.5, 2.5],
+                "label": ["a", "b"],
+            }
+        )
+        df.index = pd.to_datetime(df["time"])
+        restored = _dataframe_from_payload(_dataframe_to_payload(df))
+        if not restored.reset_index(drop=True).equals(df.reset_index(drop=True)):
+            raise AssertionError("DataFrame did not round-trip exactly")
+
+    # Controleert dat _call_key stabiel is voor gelijke argumenten en verschillend voor ongelijke.
+    def _call_key_stability():
+        k1, k2, k3 = _call_key(("a",), {}), _call_key(("a",), {}), _call_key(("b",), {})
+        if k1 != k2 or k1 == k3:
+            raise AssertionError("_call_key is not stable/discriminating")
+
+    # Controleert dat _config_hash ordeonafhankelijk is en verschilt bij een andere waarde.
+    def _config_hash_determinism():
+        a = _config_hash({"x": 1, "y": [1, 2]})
+        b = _config_hash({"y": [1, 2], "x": 1})
+        c = _config_hash({"x": 2, "y": [1, 2]})
+        if a != b or a == c:
+            raise AssertionError("_config_hash is not order-independent/discriminating")
+
+    # Controleert dat de geheimenlek-check afgaat op een geplant geheim en niets doet bij schone data.
+    def _secret_leak_gate():
+        try:
+            _assert_no_secret_leak('{"x": "leak-me"}', ["leak-me"])
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("leak gate did not fire on a planted secret")
+        _assert_no_secret_leak('{"x": "clean"}', ["leak-me"])  # must not raise
+
+    for name, fn in [
+        ("dataframe_roundtrip", _dataframe_roundtrip),
+        ("call_key_stability", _call_key_stability),
+        ("config_hash_determinism", _config_hash_determinism),
+        ("secret_leak_gate", _secret_leak_gate),
+        ("patch_list_restore", _patch_list_restore_check),
+    ]:
+        check(name, fn)
+
+    ok = all(c["ok"] for c in checks)
+    data = {"ok": ok, "checks": checks}
+
+    # Toont per zelftest of die geslaagd is.
+    def render(d):
+        for c in d["checks"]:
+            status = "ok" if c["ok"] else "FAIL"
+            suffix = f": {c['error']}" if c["error"] else ""
+            print(f"[{status}] {c['name']}{suffix}")
+        print("selftest:", "PASS" if d["ok"] else "FAIL")
+
+    _emit(args, data, render)
+    return EXIT_OK if ok else EXIT_ASSERTION_FAILED
+
+
+# -- argument parsing / entry point --------------------------------------
+
+
+# Bouwt de gedeelde --data-dir/--json-opties, herbruikt door elk subcommando zodat de vlag zowel vóór als na het subcommando werkt.
+def _common_parser() -> argparse.ArgumentParser:
+    """--data-dir and --json need to work whether given before or after the
+    subcommand name (`da_debug --json capture` and `da_debug capture --json`
+    are both natural to type) — a plain top-level-only argument only accepts
+    the former. Sharing this parent with every subparser accepts both."""
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--data-dir",
+        default=None,
+        help="Base data directory (default: <module dir>/../data, matching "
+        "day_ahead.py's own convention). All other paths resolve from here.",
+    )
+    common.add_argument("--json", action="store_true", help="Emit machine-readable JSON only.")
+    return common
+
+
+# Bouwt de volledige CLI op met alle subcommando's en hun eigen opties.
+def build_arg_parser() -> argparse.ArgumentParser:
+    common = _common_parser()
+    parser = argparse.ArgumentParser(
+        prog="python -m dao.prog.da_debug",
+        description=(
+            "Capture, replay, and inspect calc_optimum() debug snapshots. "
+            "See dao_debug_replay_ci_architecture_v2.md for the design."
+        ),
+    )
+    # --data-dir/--json are attached only to the subparsers (below), not
+    # here. argparse's subparser namespace merge overwrites a top-level
+    # flag's value with the subparser's own (unset) default for the same
+    # dest, so attaching the same parent to both levels would silently
+    # discard `da_debug --json capture` while `da_debug capture --json`
+    # worked — better to support one position correctly than both flakily.
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("capture", parents=[common], help="Run a real optimisation; write snapshot + result.")
+    p.add_argument(
+        "--config",
+        default=None,
+        help="Path to options.json (default: <data-dir>/options.json). "
+        "capture loads this directly, like an unwrapped run would — "
+        "including any in-place config migration ConfigurationLoader "
+        "performs. It is the only da_debug command that touches your real "
+        "config file; every other command that reads a config does so via "
+        "a disposable copy.",
+    )
+    p.add_argument("--out-dir", default=None, help="Where to write the snapshot (default: <data-dir>/debug_snapshots).")
+    p.add_argument("--label", default=None, help="Optional label suffix for the snapshot filename.")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Same idea as day_ahead.py's own debug mode "
+        "(calc_optimum_met_debug): sets self.debug = True before solving, "
+        "which gates most writes, plus suppresses the few that aren't "
+        "gated by that flag (self.notify(), one set_value() call — "
+        "architecture doc §1.2). All reads still happen for real and are "
+        "still captured. Use this while iterating so repeated captures "
+        "don't keep pushing real settings to HA/DB. Unrelated to --png "
+        "(see below) — that's controlled separately.",
+    )
+    p.add_argument(
+        "--png",
+        action="store_true",
+        default=False,
+        help="Keep the chart PNG day_ahead.py writes unconditionally to "
+        "../data/images (regardless of --debug). Off by default — most "
+        "capture runs don't need one and it's one more file per run — "
+        "but a chart can help spot dispatch patterns a table doesn't.",
+    )
+    p.add_argument("--start-dt", default=None, help="ISO datetime, forwarded to calc_optimum(_start_dt=...).")
+    p.add_argument("--start-soc", type=float, default=None)
+    p.add_argument("--start-ev-soc", type=float, default=None)
+
+    p = sub.add_parser("replay", parents=[common], help="Re-solve from a snapshot; needs no live HA/DB.")
+    p.add_argument("snapshot", help="Snapshot file (bare filename resolves against <data-dir>/debug_snapshots/).")
+    p.add_argument("--offline", dest="offline", action="store_true", default=True, help="Block all network access during replay (default).")
+    p.add_argument("--allow-network", dest="offline", action="store_false", help="Disable the network block (escape hatch).")
+    p.add_argument(
+        "--png",
+        action="store_true",
+        default=False,
+        help="Keep the chart PNG day_ahead.py writes unconditionally to "
+        "../data/images. Off by default, same reasoning as capture --png.",
+    )
+    p.add_argument(
+        "--threads",
+        type=int,
+        default=-1,
+        metavar="N",
+        help="CBC thread count for the replayed solve (mip.Model.threads "
+        "semantics: -1 = all cores, N = exactly N threads). Default -1. "
+        "Use --threads 1 for bit-for-bit reproducibility — slower, and can "
+        "hit day_ahead.py's fixed node cap (1500) before proving "
+        "optimality on larger models, since single-threaded CBC explores "
+        "far less of the tree per second than multi-threaded does. Any "
+        "other value lets you compare solve time/quality across thread "
+        "counts directly.",
+    )
+    p.add_argument(
+        "--out-result",
+        default=None,
+        metavar="PATH",
+        help="Where to write this replay's *.result.json (default: next "
+        "to the snapshot, named <snapshot>.replay-threads<N>.result.json — "
+        "distinct from the capture's own <snapshot>.result.json, and "
+        "distinct per thread count so replays at different --threads "
+        "don't overwrite each other). Compare with `diff`.",
+    )
+
+    p = sub.add_parser("inspect", parents=[common], help="Print snapshot meta and a content summary; no solve.")
+    p.add_argument("snapshot")
+
+    p = sub.add_parser("verify", parents=[common], help="Schema version, config hash, secret scan, integrity.")
+    p.add_argument("snapshot")
+    p.add_argument("--config", default=None, help="Optionally compare against a live options.json (copy-then-load; never mutates it).")
+    p.add_argument("--secrets", default=None, help="Optionally scan the snapshot for literal secret values from this secrets.json.")
+
+    p = sub.add_parser("diff", parents=[common], help="Compare two snapshots (inputs) or two .result.json files.")
+    p.add_argument("first")
+    p.add_argument("second")
+
+    p = sub.add_parser("set", parents=[common], help="Derive a new snapshot with overridden entity state(s).")
+    p.add_argument("snapshot")
+    p.add_argument("--state", action="append", default=[], metavar="entity_id=value", help="Repeatable.")
+    p.add_argument("--out", required=True)
+
+    p = sub.add_parser("dump", parents=[common], help="Interval dump (stub — needs A3's variable registry).")
+    p.add_argument("--snapshot", default=None)
+    p.add_argument("--interval", type=int, default=None)
+
+    sub.add_parser("selftest", parents=[common], help="Run da_debug's own offline checks.")
+
+    return parser
+
+
+_COMMANDS = {
+    "capture": cmd_capture,
+    "replay": cmd_replay,
+    "inspect": cmd_inspect,
+    "verify": cmd_verify,
+    "diff": cmd_diff,
+    "set": cmd_set,
+    "dump": cmd_dump,
+    "selftest": cmd_selftest,
+}
+
+
+# Toont een fout consistent in tekst of JSON, met traceback, vlak vóór de bijbehorende exitcode wordt teruggegeven.
+def _print_error(args: argparse.Namespace, kind: str, ex: Exception) -> None:
+    import traceback
+
+    if getattr(args, "json", False):
+        print(json.dumps({"error": kind, "message": str(ex)}, default=str))
+    else:
+        print(f"{kind}: {ex}", file=sys.stderr)
+    traceback.print_exc()
+
+
+# Entry point: parseert de argumenten, kiest het commando en vertaalt uitzonderingen naar de juiste exitcode.
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    data_dir = _resolve_data_dir(args)
+
+    handler = _COMMANDS[args.command]
+    try:
+        return handler(args, data_dir)
+    except SnapshotMiss as ex:
+        _print_error(args, "snapshot-miss", ex)
+        return EXIT_SNAPSHOT_MISS
+    except HermeticityViolation as ex:
+        _print_error(args, "hermeticity-violation", ex)
+        return EXIT_HERMETICITY_VIOLATION
+    except UsageError as ex:
+        _print_error(args, "usage-error", ex)
+        return EXIT_USAGE
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dao/requirements.txt
+++ b/dao/requirements.txt
@@ -32,3 +32,4 @@ joblib~=1.5.3
 knmi-py~=0.2.0
 asteval~=1.0.10
 tzdata~=2026.3
+freezegun~=1.5.5

--- a/dao/tests/prog/test_ev_harness_v6.py
+++ b/dao/tests/prog/test_ev_harness_v6.py
@@ -1,0 +1,1718 @@
+"""
+Automated test harness for the EV charging test plan (day_ahead.py). v2.
+
+WHAT THIS DOES
+---------------
+Runs the real `DaCalc.calc_optimum()` solver, once per test case, against
+your real config/prices/battery — but with the EV-related HA entities
+answered by canned values instead of by clicking through Home Assistant.
+It does this by monkeypatching the single method everything reads through:
+`self.get_state(entity_id).state`. Any entity_id not overridden for a given
+test case still goes to your real `get_state`, so battery, prices, the
+other EV, etc. behave exactly as they do in a normal manual run.
+
+It parses the log output the solver already produces (the setup echo, the
+"Inzet-factor laden ... per stop" table, and the summary lines under it)
+and checks each case's pass criteria automatically. It also writes a
+Markdown + CSV report to `test_reports/` when done.
+
+NEW IN v2
+----------
+- SETUP-ECHO VERIFICATION. Before judging the model's decision, each case
+  now checks that the overrides it sent actually show up in the log
+  (Huidig laadniveau, Gewenst laadniveau, Locatie, Ingeplugged, Direct
+  laden is, Klaar met laden op). If they don't match, the case is marked
+  SETUP_MISMATCH instead of FAIL — because a mismatch means the override
+  silently no-op'd (e.g. the entity is None / unconfigured for this EV),
+  and judging the model's scheduling decision on top of that is
+  meaningless. This is exactly what case 5.1 hit: `entity_instant_start`
+  is apparently `None` for the Golf, so requesting instant-on silently did
+  nothing and the model correctly evaluated instant_charge=False.
+- Case 4.3 no longer uses a raw `now + 5 minutes` offset, NOR (as of this
+  version) an end-anchored-only offset. Both were timing-fragile:
+    - `now + 5 minutes`: depends on real wall-clock position within the
+      15-minute grid, so the same "+5 min" can land anywhere from 1 to 14
+      minutes before the interval boundary depending on when you run it.
+    - anchoring only the ready deadline near the end of "the current
+      interval": still depends on where real now() happens to sit when
+      THIS SPECIFIC CASE executes within a longer run — by the time a
+      15-case batch reaches case #12, now() could already be near the end
+      of whatever interval it's in, shrinking the window right back down.
+      This is exactly what happened in the first real run: 0.230 kWh
+      achievable, still under the Golf's 1% margin (~0.363 kWh needed).
+  The fix (`ready_u_zero_full_window`) pins BOTH start_dt and ready_dt from
+  a single now() snapshot: start_dt = exact start of the current interval,
+  ready_dt = just before its end. That gives a ~14-minute window
+  independent of real wall-clock position, while still guaranteeing
+  ready_u == 0.
+- A test report (Markdown + CSV) is written after each run.
+- Solve stats (nodes / gap in particular) were silently always "—" in the
+  first real reports. Root cause: CBC's "Search completed... N nodes" and
+  "Exiting as integer gap of G..." lines are native C-level solver output,
+  never routed through Python's `logging` module, so `capture_log()` (a
+  logging.Handler) never saw them — confirmed by grep: "Rekentijd" IS a
+  `logging.info()` call in day_ahead.py (hence it always parsed), the CBC
+  node/gap lines are not logging calls at all. Fixed with
+  `capture_native_stdout()`, which redirects the OS-level stdout file
+  descriptor (not just `sys.stdout`) for the duration of the solve.
+
+NEW IN v3
+----------
+- Case 3.3 (day rollover): every other case sends the ready-datetime
+  override as a full "YYYY-MM-DD HH:MM:SS" string, which only ever
+  exercises day_ahead.py's `len(ready_str) > 9` branch. Nothing tested the
+  short "%H:%M:%S" branch or its day-rollover arithmetic. `day_rollover_
+  ready_time()` pins start_dt to 23:15 today and sends a short early-morning
+  time, forcing the source to resolve it against tomorrow's date.
+  `_predict_ready_rollover()` mirrors that exact algorithm (including its
+  coarse hour-then-minute comparison and second-dropping) so the existing
+  setup-echo verification catches it immediately if the resolved date is
+  ever wrong, off by a day, or silently not rolled over.
+- Case 6.7 (two EVs simultaneously): both cars get real, independent
+  charging needs instead of the default away/unplugged "other_input" — a
+  regression test for a previously-fixed cross-EV bug. Two mechanisms now
+  apply to EVERY case, not just 6.7, since they're cheap and directly test
+  for the same class of leak:
+    - `check_capacity()` compares each EV's echoed "Capaciteit accu" against
+      its known value (Golf 36.3 / Tesla 55.0). A mismatch means one EV's
+      log block shows the OTHER car's config — folded into SETUP_MISMATCH.
+    - the "other" EV's exclusivity (multi_stage_intervals) is now checked
+      on every case, not only when it's the case's deliberate focus.
+  `other_expect_scheduled` lets a case additionally assert the non-target
+  EV's scheduling outcome (used by 6.7; None elsewhere, meaning unchecked).
+
+NEW IN v4
+----------
+- MINIMUM DUTY CYCLE (Section 7). day_ahead.py now forces every REAL charge
+  stage to be either off or on for at least 300 s. Before that constraint,
+  the LP could give a real stage a weight of ~0.003 — a one-second charge
+  command — purely to land inside the +/-0.001 kWh `ev_energy_slack` band.
+  That is legal under every other constraint and is NOT the multi-stage
+  exclusivity bug (only one real stage is active), but it is not
+  dispatchable: a contactor can't usefully close for a second, and
+  `new_state_stop_laden` is formatted "%H:%M", which can't represent it.
+  Like the multi-stage check, the sliver check now runs on EVERY case and on
+  BOTH cars; Section 7 exists to make sure something actually walks into it.
+- The comparison uses `nominal_min_duty()` = EV_MIN_DUTY_S / interval_s,
+  which is a FLOOR on the model's true per-interval min_duty (that value is
+  larger on the short first and last intervals). Deliberately conservative:
+  it cannot produce a false positive, and can only under-report on those two
+  intervals — the alternative was re-deriving day_ahead.py's interval
+  alignment here, the same duplication that made early case 4.3 fragile.
+- Two tolerances, both learned the hard way while testing the checker
+  itself: DUTY_ZERO_TOL separates "off" from "sliver", and
+  DUTY_COMPARE_TOL exists because a legal factor of exactly 1/3 is LOGGED as
+  "0.3333" — without it, every correctly-constrained minimum-duty interval
+  would be reported as a violation.
+- `soc_factory` / `remainder_soc_factory()`: Section 7's cases must derive
+  their SoC pair backwards from the car's own top-stage delivery, so that
+  energy_needed is N full intervals plus a remainder too small to deliver in
+  one 5-minute action. Hardcoded percentages would provoke a sliver only by
+  luck, since an arbitrary remainder is uniformly distributed.
+- `expect_partial_at_least`: Section 7's cases are NEGATIVE tests, so if the
+  engineered remainder ever stops landing partway through an interval they
+  would pass while testing nothing. This fails them loudly instead. The
+  count is stable across the fix — the remainder interval is partial either
+  way, only its size changes.
+- Report gains a "Min factor" column plus `duty_slivers`,
+  `min_nonzero_factor` and `min_duty_guard_fired` in the CSV.
+
+NEW IN v5
+----------
+- RETUNED 7.1/7.2/7.4 (Golf, non-monotonic curve). A min_duty_s=0 control
+  run showed these three barely moved between fix-on and fix-off — min
+  factor 0.9998 on 7.2, near-unchanged on 7.1/7.4 — meaning the Golf's curve
+  let the solver absorb the engineered remainder via stage substitution
+  (switching amperage for a whole interval) instead of a short duty cycle,
+  so the minimum-duty constraint was never actually being exercised on
+  these three. 7.3/7.5 (Tesla, monotone curve — no substitution option) DID
+  show clear slivers under the same control run, which is what exposed the
+  gap: it wasn't the assertion that was wrong, it was that these three
+  cases weren't reaching the code path they claim to test.
+  `remainder_kwh` raised from 0.02-0.04 kWh to 0.20-0.24 kWh on all three,
+  still under the Golf's ~0.28 kWh single-switch floor (lowest stage's
+  accu_power * 300s), to make duty-cycling cheaper than substitution.
+  Before trusting these again: re-run with min_duty_s=0 and confirm they
+  now fail with reported slivers the way 1.T/7.3/7.5 did; only then re-run
+  at the real min_duty_s and confirm clean.
+
+NEW IN v6
+----------
+- BUG 7 REGRESSION (Section 5). day_ahead.py reads entity_ready_datetime
+  and derives hours_avail *unconditionally*, before instant_charge is ever
+  consulted — that value then feeds the "te weinig tijd" clamp
+  (`e_needed > max_possible` -> wished_level pulled down toward whatever's
+  reachable by that deadline). Nothing in that clamp checks instant_charge,
+  so a tight or stale entity_ready_datetime can silently undercharge an
+  instant-charge request. 5.1 never actually exercised this: it pins
+  ready_dt 8 hours out, so hours_avail was always generous and the clamp
+  had no reason to fire — a PASS there says nothing about the bug either
+  way. New case 5.2 pins ready_dt to +15 minutes instead, which should
+  provoke the clamp hard (well under 1 kWh reachable vs. ~25.4 kWh needed)
+  if the bug is live, and both cases now assert
+  expect_wished_level_clipped=False so the clamp firing is a hard FAIL
+  instead of a silent, invisible pass.
+- New `wished_level_clipped` signal, parsed from the "Er is te weinig
+  tijd" log line within the same per-EV setup block already used for
+  `energy_needed_kwh` (so it's scoped by EV name the same way). Asserted
+  via `expect_wished_level_clipped`; also written to the CSV for any case
+  that doesn't assert it, the same way `min_nonzero_factor` is reported
+  without being asserted everywhere.
+- Do not trust a PASS on an instant-charge case as evidence about Bug 7
+  unless you've checked that case actually controls ready_dt to something
+  short. A generous or unset ready_dt (leaving the real HA entity alone)
+  makes the case blind to this bug by construction — confirmed the hard
+  way: an earlier run's raw log showed "Klaar met laden op: 25-07-2026
+  21:58:28" for 5.1, consistent with its own pinned +8h window, not with
+  whatever the live entity_ready_datetime happened to hold at the time.
+
+WHAT THIS DOES NOT DO
+----------------------
+It does not fabricate price or battery data — those still come from your
+live setup, so run this on a day where day-ahead prices are actually
+loaded, same as a manual debug run. It also doesn't replace judgement on
+the "known issues, observe don't chase" section of the test plan — those
+are printed but not failed.
+
+SAFETY: WHY THIS FORCES self.debug = True
+-------------------------------------------
+`self.debug` isn't only a logging flag — it also gates every real write to
+Home Assistant in the EV dispatch block (`set_value`, `turn_on`, `turn_off`,
+`call_service`, plus a couple of prognosis-saving calls earlier). With
+debug=False those calls execute for real. `calc_optimum_debug()` sets
+`self.debug = True` for you, but it's a zero-argument wrapper around
+`calc_optimum()` and can't accept the `_start_dt` this harness needs per
+case. So `run_case()` sets `da_calc.debug = True` itself, immediately before
+every solve call — this is not optional, it's what keeps this script from
+actually toggling your chargers. If you ever change `run_case()`, keep that
+line.
+
+SETUP REQUIRED FROM YOU
+-------------------------
+1. Set EV_INDEX_TESLA / EV_INDEX_GOLF below (or leave the name-matching
+   autodetect, see `_find_ev_index`).
+2. Confirm `import` path / working directory matches how you normally run
+   day_ahead.py (this assumes it's importable as `day_ahead`).
+3. Case 4.4/4.5 mutate `entity_stop_charging` on the live config object and
+   restore it afterwards. If `ev_options[e]` is a frozen pydantic model,
+   direct attribute assignment will raise — see `_with_stop_entity_removed`
+   for the fallback path, and adjust it to match your actual config class
+   if needed (I could not see da_base.py / the config schema from here).
+4. If 5.1 still shows SETUP_MISMATCH after this update: `entity_instant_start`
+   is genuinely unconfigured for the Golf in your options.json. Either add
+   it there, or retarget that case at the Tesla (change target="tesla").
+
+Run:
+    python test_ev_harness.py
+"""
+
+from __future__ import annotations
+
+import csv
+import ctypes
+import datetime as dt
+import io
+import logging
+import os
+import re
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional, Union
+
+from day_ahead import DaCalc  # adjust import if your entrypoint differs
+
+CONFIG_PATH = "../data/options.json"  # matches main() in day_ahead.py
+REPORT_DIR = Path("test_reports")
+
+# --- minimum duty cycle (see EV handover addendum, §19 under Bug 2) ---------
+# day_ahead.py constrains every REAL charge stage (cs >= 1) to be either off
+# or on for at least EV_MIN_DUTY_S seconds, via
+#     stage_factor[e][cs][u] >= min_duty * stage_on[e][cs][u]
+# with min_duty = min(1.0, EV_MIN_DUTY_S / (hr_fraction * 3600)).
+# Keep this in sync with `ev_min_duty_s` in day_ahead.py.
+EV_MIN_DUTY_S = 300.0
+
+# Tolerance below which a stage_factor is treated as "off" rather than as a
+# sliver. The factor table is logged to 4 decimals, so anything at or under
+# 1e-4 is indistinguishable from zero in the parsed output anyway.
+DUTY_ZERO_TOL = 1e-4
+
+# Slack when comparing a factor against min_duty. Two effects stack here and
+# both are one-sided against us:
+#   - the factor table is logged to 4 decimals, so a legal value of exactly
+#     1/3 prints as "0.3333", which is BELOW min_duty by 3.3e-5;
+#   - CBC satisfies constraints to its own feasibility tolerance, so a
+#     legal value can sit a hair under the bound in the solution itself.
+# Without this slack, every correctly-constrained interval at exactly the
+# minimum duty would be reported as a violation. 1e-4 is four orders of
+# magnitude below a real sliver (~0.003 against a min_duty of 0.333), so it
+# costs no detection power.
+DUTY_COMPARE_TOL = 1e-4
+
+_libc = ctypes.CDLL(None)
+
+# ---------------------------------------------------------------------------
+# Fake HA state plumbing
+# ---------------------------------------------------------------------------
+
+
+class FakeState:
+    """Mimics whatever object self.get_state(...) normally returns — only
+    `.state` is ever read in the EV code path."""
+
+    def __init__(self, value):
+        self.state = str(value)
+
+
+@contextmanager
+def get_state_overrides(da_calc: DaCalc, overrides: dict[str, object]):
+    """Temporarily replace da_calc.get_state so that entity_ids in
+    `overrides` return canned values, and everything else still hits the
+    real get_state. Restores the original method on exit even if the run
+    raises."""
+    real_get_state = da_calc.get_state
+
+    def patched(entity_id, *args, **kwargs):
+        if entity_id in overrides:
+            return FakeState(overrides[entity_id])
+        return real_get_state(entity_id, *args, **kwargs)
+
+    da_calc.get_state = patched
+    try:
+        yield
+    finally:
+        da_calc.get_state = real_get_state
+
+
+@contextmanager
+def capture_log():
+    """Capture everything logged during the run (same records that go to
+    your console/log file) into a StringIO, INFO and above, then remove
+    the handler afterwards."""
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root = logging.getLogger()
+    prev_level = root.level
+    root.setLevel(min(prev_level, logging.INFO))
+    root.addHandler(handler)
+    try:
+        yield buf
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(prev_level)
+
+
+@contextmanager
+def capture_native_stdout():
+    """Captures OS-level file descriptor 1 (real stdout), which is what
+    CBC's native solver actually writes to via its own C-level printf-style
+    calls. These lines never pass through Python's `logging` module, so
+    `capture_log()` — a logging.Handler — is structurally blind to them.
+    This is confirmed by grepping day_ahead.py: "Rekentijd" is a
+    logging.info() call (hence it parses fine), but "Cbc0001I Search
+    completed..." and "Cbc0011I Exiting as integer gap..." don't appear in
+    any logging call in the file at all.
+
+    Plain `contextlib.redirect_stdout` would NOT catch this — it only
+    reassigns Python's `sys.stdout` object, and C extensions writing via
+    native stdio bypass that entirely. This redirects the actual OS file
+    descriptor instead, and explicitly flushes libc's stdio buffers with
+    `fflush(NULL)` before restoring it, since output written to a
+    non-tty (our temp file) is typically fully buffered rather than
+    line-buffered and could otherwise sit unflushed in CBC's internal
+    buffer past the point where we read it back — or worse, leak into the
+    next test case's capture once eventually flushed.
+
+    Usage: `with capture_native_stdout() as native: ...` then read
+    `native["text"]` AFTER the with-block exits (it's populated in this
+    generator's `finally`, which runs during `__exit__`, before control
+    returns to the caller).
+    """
+    stdout_fd = 1
+    saved_fd = os.dup(stdout_fd)
+    tmp = tempfile.TemporaryFile(mode="w+b")
+    _libc.fflush(None)
+    os.dup2(tmp.fileno(), stdout_fd)
+    result = {"text": ""}
+    try:
+        yield result
+    finally:
+        _libc.fflush(None)
+        os.dup2(saved_fd, stdout_fd)
+        os.close(saved_fd)
+        tmp.seek(0)
+        result["text"] = tmp.read().decode(errors="replace")
+        tmp.close()
+
+
+@contextmanager
+def _with_stop_entity_removed(da_calc: DaCalc, ev_index: int):
+    """Case 4.4/4.5 support: temporarily make entity_stop_charging look
+    absent for one EV. Tries plain attribute assignment first (works if
+    ev_options[e] is a plain object / mutable pydantic model). If that
+    raises (frozen model), falls back to swapping in a shallow copy via
+    model_copy — ADAPT THIS if your config class differs."""
+    ev = da_calc.ev_options[ev_index]
+    original = ev.entity_stop_charging
+    try:
+        ev.entity_stop_charging = None
+        restore = lambda: setattr(ev, "entity_stop_charging", original)
+    except Exception:
+        new_ev = ev.model_copy(update={"entity_stop_charging": None})
+        da_calc.ev_options[ev_index] = new_ev
+        restore = lambda: da_calc.ev_options.__setitem__(ev_index, ev)
+    try:
+        yield
+    finally:
+        restore()
+
+
+@contextmanager
+def _null_ctx():
+    yield
+
+
+def _find_ev_index(da_calc: DaCalc, name_substring: str) -> int:
+    for i, ev in enumerate(da_calc.ev_options):
+        if name_substring.lower() in ev.name.lower():
+            return i
+    raise ValueError(f"No EV config found matching {name_substring!r}")
+
+
+# ---------------------------------------------------------------------------
+# Timing helper for case 4.3 (ready_u == 0), grid-anchored instead of
+# wall-clock-offset
+# ---------------------------------------------------------------------------
+
+
+def ready_u_zero_full_window(
+    buffer_seconds: int = 45,
+) -> Callable[[DaCalc], tuple[dt.datetime, dt.datetime, Optional[str]]]:
+    """Returns a factory (da_calc) -> (start_dt, ready_dt) for a ready_u==0
+    test with a near-full interval's charging window, regardless of when
+    in a multi-case run this particular case happens to execute.
+
+    First attempt at this (anchoring only the ready deadline near the end
+    of "the current interval") was NOT enough: by the time a later case in
+    a run executes, real now() could already be sitting anywhere inside
+    that interval — including near its own end — so the achievable window
+    (ready - now) could still shrink to a couple of minutes by pure timing
+    luck. That's what happened: 0.230 kWh needed, still under the 1%
+    margin (which needs ~0.363 kWh / ~6.4 minutes at the Golf's max power
+    to clear).
+
+    The fix pins BOTH ends to the same interval, from a single now()
+    snapshot: start_dt = the exact beginning of the interval now() is in,
+    ready_dt = buffer_seconds before its end. That gives a ~14-minute
+    window (at 900s intervals) independent of real wall-clock position,
+    while still guaranteeing ready_u == 0 (ready falls inside the interval
+    calc_optimum treats as u=0, since start_dt IS that interval's start).
+    """
+
+    def _factory(da_calc: DaCalc) -> tuple[dt.datetime, dt.datetime]:
+        interval_s = da_calc.interval_s
+        now_ts = int(dt.datetime.now().timestamp())
+        start_of_interval_ts = interval_s * (now_ts // interval_s)
+        end_of_interval_ts = start_of_interval_ts + interval_s
+        start_dt = dt.datetime.fromtimestamp(start_of_interval_ts)
+        ready_dt = dt.datetime.fromtimestamp(end_of_interval_ts - buffer_seconds)
+        return start_dt, ready_dt, None
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Day-rollover helper for the short "HH:MM:SS" ready-datetime format
+# ---------------------------------------------------------------------------
+
+
+def _predict_ready_rollover(start_dt: dt.datetime, hh_mm_ss: str) -> dt.datetime:
+    """Mirrors day_ahead.py's short-format ready-datetime parsing exactly
+    (the `else` branch, len(ready_str) <= 9):
+
+        ready = dt.datetime.strptime(ready_str, "%H:%M:%S")
+        ready = dt.datetime(start_dt.year, start_dt.month, start_dt.day,
+                             ready.hour, ready.minute)
+        if (ready.hour == start_dt.hour and ready.minute < start_dt.minute) or (
+            ready.hour < start_dt.hour
+        ):
+            ready = ready + dt.timedelta(days=1)
+
+    Note the comparison is coarse (hour first, minute only as a tiebreak on
+    equal hour) and seconds are dropped entirely — reproduced verbatim here
+    so the harness predicts exactly what the source will compute, not an
+    approximation of it.
+    """
+    t = dt.datetime.strptime(hh_mm_ss, "%H:%M:%S")
+    ready = dt.datetime(start_dt.year, start_dt.month, start_dt.day, t.hour, t.minute)
+    if (ready.hour == start_dt.hour and ready.minute < start_dt.minute) or (
+        ready.hour < start_dt.hour
+    ):
+        ready = ready + dt.timedelta(days=1)
+    return ready
+
+
+def day_rollover_ready_time(
+    hour: int = 1, minute: int = 0
+) -> Callable[[DaCalc], tuple[dt.datetime, dt.datetime, str]]:
+    """Returns a factory (da_calc) -> (start_dt, predicted_ready_dt,
+    ready_override_str) that tests the SHORT ready-datetime format and its
+    day-rollover arithmetic — a code path nothing in this suite exercised
+    before, since every other case sends a full "YYYY-MM-DD HH:MM:SS"
+    string (the `len(ready_str) > 9` branch). This deliberately targets the
+    `else` branch and its rollover-to-tomorrow logic.
+
+    start_dt is pinned to 23:15 on the current real calendar date — late
+    enough that an early-morning `hour:minute` is unambiguously "earlier"
+    by the source's own hour/minute comparison, and still today's date, so
+    today's already-published day-ahead prices cover it. ready_override_str
+    is a short "HH:MM:SS" string for the given hour/minute, which forces
+    the model to resolve it against tomorrow's date — genuinely spanning
+    midnight in the optimisation horizon, not just in the string parsing.
+    """
+
+    def _factory(da_calc: DaCalc) -> tuple[dt.datetime, dt.datetime, str]:
+        today = dt.date.today()
+        start_dt = dt.datetime(today.year, today.month, today.day, 23, 15)
+        ready_override_str = f"{hour:02d}:{minute:02d}:00"
+        predicted_ready = _predict_ready_rollover(start_dt, ready_override_str)
+        return start_dt, predicted_ready, ready_override_str
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Test case definition
+# ---------------------------------------------------------------------------
+
+ReadyDtSpec = Union[dt.datetime, Callable[[DaCalc], dt.datetime], None]
+
+
+@dataclass
+class EvCaseInput:
+    plugged_in: Optional[bool] = None
+    position: Optional[str] = None  # "home" / "away"
+    actual_soc: Optional[float] = None
+    instant_charge: Optional[bool] = None
+    wished_level: Optional[float] = None
+    ready_dt: ReadyDtSpec = None  # None -> leave real entity alone
+    # When set, this exact string is sent as the ready-datetime HA state
+    # instead of formatting ready_dt as "%Y-%m-%d %H:%M:%S". Use for testing
+    # the short "%H:%M:%S" parsing branch (day_ahead.py's len(ready_str) <= 9
+    # path) — ready_dt should still be set (or resolved via dynamic_setup)
+    # to the PREDICTED result, so setup-echo verification has something to
+    # check against.
+    ready_override_str: Optional[str] = None
+
+
+@dataclass
+class ResolvedEvInput:
+    """Same shape as EvCaseInput but with ready_dt fully resolved to a
+    concrete datetime (or None), so it can be reused both for building
+    overrides and for verifying the log echo without calling a
+    now()-dependent factory twice."""
+    plugged_in: Optional[bool]
+    position: Optional[str]
+    actual_soc: Optional[float]
+    instant_charge: Optional[bool]
+    wished_level: Optional[float]
+    ready_dt: Optional[dt.datetime]
+    ready_override_str: Optional[str] = None
+
+
+def _resolve(da_calc: DaCalc, inp: EvCaseInput) -> ResolvedEvInput:
+    ready = inp.ready_dt(da_calc) if callable(inp.ready_dt) else inp.ready_dt
+    return ResolvedEvInput(
+        plugged_in=inp.plugged_in,
+        position=inp.position,
+        actual_soc=inp.actual_soc,
+        instant_charge=inp.instant_charge,
+        wished_level=inp.wished_level,
+        ready_dt=ready,
+        ready_override_str=inp.ready_override_str,
+    )
+
+
+@dataclass
+class TestCase:
+    id: str
+    description: str
+    target: str  # "tesla" or "golf" -- which EV_INDEX_* to use as the target
+    target_input: EvCaseInput
+    other_input: EvCaseInput = field(
+        default_factory=lambda: EvCaseInput(plugged_in=False, position="away")
+    )
+    start_dt: Optional[dt.datetime] = None  # None -> now
+    # For cases where start_dt and target_input.ready_dt (and optionally a
+    # raw ready_override_str) must be derived from the SAME now() snapshot
+    # (e.g. ready_u_zero_full_window, day_rollover_ready_time) rather than
+    # resolved independently. When set, overrides start_dt,
+    # target_input.ready_dt, and target_input.ready_override_str at run
+    # time. Third tuple element is None to leave ready_override_str as
+    # whatever target_input already had.
+    dynamic_setup: Optional[
+        Callable[[DaCalc], tuple[dt.datetime, dt.datetime, Optional[str]]]
+    ] = None
+    remove_stop_entity_on_target: bool = False
+    # Computes (actual_soc, wished_level) for the TARGET ev from its real
+    # config at run time, overriding whatever target_input carried. Needed by
+    # the minimum-duty cases, which must derive the SoC pair backwards from
+    # the car's own top-stage delivery rather than hardcoding percentages —
+    # see remainder_soc_factory.
+    soc_factory: Optional[Callable[[DaCalc, int], tuple[float, float]]] = None
+    # pass criteria
+    expect_scheduled: Optional[bool] = None  # None -> don't check
+    expect_reason_substr: Optional[str] = None
+    expect_ready_index_zero: bool = False
+    # When set, also parses and checks the OTHER EV's scheduling outcome —
+    # used for the two-EVs-simultaneously case, where both cars have real
+    # charging needs rather than the default away/unplugged "other_input".
+    other_expect_scheduled: Optional[bool] = None
+    # Minimum number of partial-duty intervals the case must produce. Used by
+    # the minimum-duty cases as a "does this case still bite?" guard: they are
+    # NEGATIVE tests (assert no slivers), so if the engineered remainder ever
+    # stops landing partway through an interval, they would silently pass
+    # while testing nothing. Note this count is stable across the fix — the
+    # remainder interval is partial either way, only its size changes.
+    expect_partial_at_least: Optional[int] = None
+    # Whether the model's min-duty feasibility guard ("minimale schakelduur
+    # ... wordt niet toegepast") is expected to fire. None -> don't check.
+    expect_min_duty_guard: Optional[bool] = None
+    # Whether day_ahead.py is expected to clip wished_level down for
+    # insufficient time ("Er is te weinig tijd..."). None -> don't check.
+    # For instant_charge cases this should be explicitly False: instant
+    # charge is supposed to ignore entity_ready_datetime entirely, so if
+    # this fires despite instant_charge=True, that's Bug 7 (day_ahead.py
+    # reads hours_avail from entity_ready_datetime unconditionally, before
+    # the instant_charge branch is ever consulted).
+    expect_wished_level_clipped: Optional[bool] = None
+
+
+def _now_plus(hours: float = 0, minutes: float = 0) -> dt.datetime:
+    return dt.datetime.now() + dt.timedelta(hours=hours, minutes=minutes)
+
+
+# ---------------------------------------------------------------------------
+# Minimum-duty helpers
+# ---------------------------------------------------------------------------
+
+
+def nominal_min_duty(da_calc: DaCalc) -> float:
+    """Lower bound on the true per-interval `min_duty` used by the model.
+
+    day_ahead.py computes min_duty = min(1.0, EV_MIN_DUTY_S / (hr_fraction *
+    3600)) per interval. `hr_fraction * 3600` is at most `interval_s` (it is
+    SHORTER at u=0, because the solve rarely starts on an interval boundary,
+    and at u=ready_u, which runs only until the deadline). A shorter interval
+    means a LARGER min_duty, so `EV_MIN_DUTY_S / interval_s` is a floor on
+    min_duty across every interval.
+
+    Using the floor makes the sliver check conservative in the right
+    direction: it can never produce a false positive, and can only miss a
+    violation on the first or last interval — the two intervals whose exact
+    hr_fraction the harness cannot reconstruct from the log without
+    duplicating day_ahead.py's own interval-alignment arithmetic (the very
+    duplication that made earlier versions of case 4.3 timing-fragile).
+    """
+    interval_s = float(getattr(da_calc, "interval_s", 900))
+    return min(1.0, EV_MIN_DUTY_S / interval_s)
+
+
+def _top_stage_accu_kw(da_calc: DaCalc, ev_index: int) -> float:
+    """Accu-side kW of the highest charge stage, mirroring day_ahead.py's
+    own derivation (ampere x phases x 230 / 1000 x efficiency)."""
+    ev = da_calc.ev_options[ev_index]
+    stages = ev.charge_stages
+    top = stages[-1]
+    ampere = float(getattr(top, "ampere", 0.0))
+    efficiency = float(getattr(top, "efficiency", 1.0) or 1.0)
+    try:
+        ha_getter = lambda eid: da_calc.get_state(eid).state
+        three_phase = bool(ev.charge_three_phase.resolve(ha_getter))
+    except Exception:  # noqa: BLE001 - config shape varies, see docstring
+        three_phase = False
+    phases = 3 if three_phase else 1
+    return ampere * phases * 230 / 1000 * efficiency
+
+
+def remainder_soc_factory(
+    full_intervals: int,
+    remainder_kwh: float,
+    base_soc: float = 30.0,
+) -> Callable[[DaCalc, int], tuple[float, float]]:
+    """Build a (actual_soc, wished_level) factory that engineers a small
+    leftover on top of a whole number of full-power intervals.
+
+    The sliver defect only surfaces when the optimizer wants to run N
+    intervals at full duty plus a tiny fraction of one more, to land inside
+    the +/-0.001 kWh `ev_energy_slack` band. An arbitrary SoC pair produces a
+    uniformly-distributed remainder, so it provokes a sliver only rarely.
+    This computes the SoC percentages backwards from the car's own top-stage
+    delivery so the remainder is deliberately tiny:
+
+        e_needed = full_intervals * (top_stage_accu_kW * interval_hours)
+                   + remainder_kwh
+
+    `remainder_kwh` should be comfortably below the smallest amount the fixed
+    model can deliver in one switching action (top_stage_accu_kW *
+    EV_MIN_DUTY_S / 3600), so that the PRE-fix code has to answer it with a
+    sliver and the POST-fix code is forced to redistribute instead.
+    """
+
+    def factory(da_calc: DaCalc, ev_index: int) -> tuple[float, float]:
+        ev = da_calc.ev_options[ev_index]
+        capacity = float(ev.capacity)
+        interval_h = float(getattr(da_calc, "interval_s", 900)) / 3600
+        per_interval = _top_stage_accu_kw(da_calc, ev_index) * interval_h
+        e_needed = full_intervals * per_interval + remainder_kwh
+        wished = base_soc + (e_needed / capacity) * 100
+        if wished > 100.0:
+            raise ValueError(
+                f"remainder_soc_factory: full_intervals={full_intervals} needs "
+                f"{e_needed:.3f} kWh, which exceeds EV {ev.name}'s capacity "
+                f"from {base_soc}% — lower full_intervals or base_soc."
+            )
+        # 4 decimals: the setup echo logs SoC as a plain float, and the model
+        # reads it back as a float, so extra precision is neither lost nor
+        # needed.
+        return round(base_soc, 4), round(wished, 4)
+
+    return factory
+
+
+CASES: list[TestCase] = [
+    # --- Section 1: core exclusivity (Golf only) ---
+    TestCase(
+        id="1.1",
+        description="Golf blend trap: 30->63%, ready +4h, ~3.00 kW avg",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0, ready_dt=_now_plus(hours=4),
+        ),
+        expect_scheduled=True,
+    ),
+    TestCase(
+        id="1.2",
+        description="Golf near 16A ceiling: 30->67%, ready +4h",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=67.0, ready_dt=_now_plus(hours=4),
+        ),
+        expect_scheduled=True,
+    ),
+    TestCase(
+        id="1.3",
+        description="Golf below 10A capacity: 30->63%, ready +8h",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0, ready_dt=_now_plus(hours=8),
+        ),
+        expect_scheduled=True,
+    ),
+    TestCase(
+        id="1.4",
+        description="Golf small job, lots of slack: 30->40%, ready +2h",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=40.0, ready_dt=_now_plus(hours=2),
+        ),
+        expect_scheduled=True,
+    ),
+    TestCase(
+        id="1.5",
+        description="Golf above max power: 30->63%, ready +3h20m -> auto-adjusted",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0,
+            ready_dt=_now_plus(hours=3, minutes=20),
+        ),
+        expect_scheduled=True,
+    ),
+    # --- Section 2: scheduling decision branches ---
+    TestCase(
+        id="2.1", description="Already at target level",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=80.0,
+            instant_charge=False, wished_level=80.0, ready_dt=_now_plus(hours=2),
+        ),
+        expect_scheduled=False,
+        expect_reason_substr="hoger is of gelijk aan",
+    ),
+    TestCase(
+        id="2.2", description="Car away",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="away", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0, ready_dt=_now_plus(hours=4),
+        ),
+        expect_scheduled=False,
+        expect_reason_substr="auto is niet huis",
+    ),
+    TestCase(
+        id="2.3", description="Not plugged in",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=False, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0, ready_dt=_now_plus(hours=4),
+        ),
+        expect_scheduled=False,
+        expect_reason_substr="auto is niet ingeplugd",
+    ),
+    TestCase(
+        id="2.4", description="Ready time in the past",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0,
+            ready_dt=_now_plus(hours=-24),
+        ),
+        expect_scheduled=False,
+        expect_reason_substr="is verouderd",
+    ),
+    TestCase(
+        id="2.5", description="Ready beyond horizon",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0,
+            ready_dt=_now_plus(hours=30),
+        ),
+        expect_scheduled=False,
+        expect_reason_substr="ligt voorbij de planningshorizon",
+    ),
+    TestCase(
+        id="2.6", description="Combine away + unplugged + stale ready",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=False, position="away", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0,
+            ready_dt=_now_plus(hours=-24),
+        ),
+        expect_scheduled=False,
+    ),
+    # --- Section 4: partial duty / stage 0, no-stop-entity guard ---
+    TestCase(
+        id="4.3",
+        description="Ready near end of current interval -> ready_u == 0",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=60.0,
+            instant_charge=False, wished_level=63.0,
+        ),
+        dynamic_setup=ready_u_zero_full_window(45),
+        expect_scheduled=True,
+    ),
+    TestCase(
+        id="4.4", description="No stop entity, blend-trap case -> interval 0 must be 0/1",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0, ready_dt=_now_plus(hours=4),
+        ),
+        remove_stop_entity_on_target=True,
+        expect_scheduled=True,
+    ),
+    # --- Section 5: instant charge ---
+    TestCase(
+        id="5.1",
+        description="Instant charge on, Golf 30%, generous deadline (baseline)",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0, instant_charge=True, wished_level=100.0,
+	    ready_dt=_now_plus(hours=8),
+        ),
+        expect_scheduled=True,
+        expect_wished_level_clipped=False,
+    ),
+    TestCase(
+        id="5.2",
+        description=(
+            "Bug 7 regression: instant charge on, Golf 30%, but "
+            "entity_ready_datetime deliberately short (+15 min). Instant "
+            "charge must ignore this deadline entirely — day_ahead.py "
+            "reads hours_avail from entity_ready_datetime unconditionally, "
+            "before instant_charge is checked, so a tight/stale value "
+            "there can silently clip wished_level even though instant "
+            "charge is supposed to override it. Golf's max charge rate "
+            "(~3.68 kW) over 15 min gives well under 1 kWh 'available', "
+            "vs. the ~25.4 kWh a 30%->100% target actually needs, so if "
+            "this bug is live the clip fires hard and unambiguously."
+        ),
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0, instant_charge=True,
+            wished_level=100.0, ready_dt=_now_plus(minutes=15),
+        ),
+        expect_scheduled=True,
+        expect_wished_level_clipped=False,
+    ),
+    TestCase(
+        id="1.6",
+        description=(
+            "Zero-slack energy_needed infeasibility regression: Golf 30%, "
+            "ready +1h50m (clamped to max_possible, per fix prompt's exact repro)"
+        ),
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=90.0,
+            ready_dt=_now_plus(hours=1, minutes=50),
+        ),
+        expect_scheduled=True,
+    ),
+    # --- Section 3: ready-time parsing (short format + day rollover) ---
+    TestCase(
+        id="3.3",
+        description="Day rollover: short HH:MM:SS ready time, earlier than start -> next day",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0,
+        ),
+        dynamic_setup=day_rollover_ready_time(hour=1, minute=0),
+        expect_scheduled=True,
+    ),
+    # --- Section 6.7: two EVs scheduled simultaneously (regression test for
+    # a previously-fixed cross-EV bug) ---
+    TestCase(
+        id="6.7",
+        description="Two EVs simultaneously: Golf 30->63% + Tesla 35->80%, both ready +4h",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=30.0,
+            instant_charge=False, wished_level=63.0, ready_dt=_now_plus(hours=4),
+        ),
+        other_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=35.0,
+            instant_charge=False, wished_level=80.0, ready_dt=_now_plus(hours=4),
+        ),
+        expect_scheduled=True,
+        other_expect_scheduled=True,
+    ),
+    # --- Section 1, Tesla control case (should NOT need to blend) ---
+    TestCase(
+        id="1.T", description="Tesla control: monotone curve, should single-stage trivially",
+        target="tesla",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=35.0,
+            instant_charge=False, wished_level=80.0, ready_dt=_now_plus(hours=3),
+        ),
+        expect_scheduled=True,
+    ),
+    # --- Section 7: minimum duty cycle (EV handover addendum §19, Bug 2) ---
+    # These provoke the sub-tolerance duty sliver: the LP giving a REAL stage
+    # a weight of ~0.003 (roughly a one-second charge command) purely to land
+    # inside the +/-0.001 kWh ev_energy_slack band. Legal before the fix,
+    # not dispatchable — a contactor can't usefully close for a second, and
+    # the stop time is formatted "%H:%M".
+    #
+    # Each case engineers energy_needed to be a whole number of full-power
+    # intervals plus a remainder far too small to deliver in one 5-minute
+    # switching action, so the pre-fix solver has to answer with a sliver and
+    # the post-fix solver is forced to redistribute across intervals instead.
+    #
+    # The assertion itself lives in run_case and applies to every case in
+    # this file; Section 7 exists to make sure something actually walks into
+    # it. expect_partial_at_least guards against these quietly ceasing to
+    # provoke anything.
+    TestCase(
+        id="7.1",
+        description="Golf duty sliver, slack window: 6 full intervals + 0.22 kWh, ready +6h",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home",
+            instant_charge=False, ready_dt=_now_plus(hours=6),
+        ),
+        # v4 used 0.02 kWh here. Empirically (min_duty_s=0 run) that let the
+        # Golf's non-monotonic curve resolve the remainder via stage
+        # substitution instead of a short duty cycle — min factor barely
+        # moved between fix-on and fix-off. Raised to 0.22 kWh, still under
+        # the Golf's ~0.28 kWh single-switch floor (min stage accu_power *
+        # 300s), so substitution remains worse than one short duty cycle.
+        soc_factory=remainder_soc_factory(full_intervals=6, remainder_kwh=0.22),
+        expect_scheduled=True,
+        expect_partial_at_least=1,
+    ),
+    TestCase(
+        id="7.2",
+        description="Golf duty sliver, near-saturated window: 10 full intervals + 0.24 kWh, ready +3h",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home",
+            instant_charge=False, ready_dt=_now_plus(hours=3),
+        ),
+        # ~10 of ~12 available intervals must be full, so the optimizer has
+        # almost no freedom about WHERE to put the remainder — a different
+        # branch from 7.1, where it can shop for the cheapest interval.
+        # v4's 0.04 kWh remainder produced a 0.9998 min factor (essentially
+        # full, no sliver even with min_duty_s=0) — same substitution
+        # failure mode as 7.1, raised for the same reason.
+        soc_factory=remainder_soc_factory(full_intervals=10, remainder_kwh=0.24),
+        expect_scheduled=True,
+        expect_partial_at_least=1,
+    ),
+    TestCase(
+        id="7.3",
+        description="Tesla duty sliver (monotone curve control): 6 full intervals + 0.02 kWh, ready +5h",
+        target="tesla",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home",
+            instant_charge=False, ready_dt=_now_plus(hours=5),
+        ),
+        # The Tesla's curve is monotone, so unlike the Golf there is never a
+        # cost reason to blend stages. If a sliver shows up HERE it is purely
+        # the energy-band remainder, with the non-monotonic-curve explanation
+        # ruled out.
+        soc_factory=remainder_soc_factory(full_intervals=6, remainder_kwh=0.02, base_soc=35.0),
+        expect_scheduled=True,
+        expect_partial_at_least=1,
+    ),
+    TestCase(
+        id="7.4",
+        description="Golf duty sliver with no stop entity: 4 full intervals + 0.20 kWh, ready +4h",
+        target="golf",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home",
+            instant_charge=False, ready_dt=_now_plus(hours=4),
+        ),
+        # v4's 0.02 kWh remainder was absorbed by substitution (min factor
+        # 0.3949 with min_duty_s=0 — barely below the bound, not the clear
+        # sliver 7.3/7.5 showed). Raised for the same reason as 7.1/7.2.
+        soc_factory=remainder_soc_factory(full_intervals=4, remainder_kwh=0.20),
+        # Without entity_stop_charging, day_ahead.py already forces interval 0
+        # to be fully on or fully off. This checks the two mechanisms compose:
+        # interval 0 all-or-nothing AND every other interval respecting the
+        # minimum duty, with the model still feasible.
+        remove_stop_entity_on_target=True,
+        expect_scheduled=True,
+        expect_partial_at_least=1,
+    ),
+    TestCase(
+        id="7.5",
+        description="Tesla small top-up near the min-duty feasibility guard: 60->61.2%",
+        target="tesla",
+        target_input=EvCaseInput(
+            plugged_in=True, position="home", actual_soc=60.0,
+            instant_charge=False, wished_level=61.2, ready_dt=_now_plus(hours=2),
+        ),
+        # ~0.66 kWh total. Whether this trips day_ahead.py's guard (skip the
+        # minimum-duty constraint when energy_needed is below one switching
+        # action) depends on this car's top-stage power: at 3-phase 16A one
+        # 5-minute action already delivers ~0.92 kWh, so the guard fires; at
+        # 1-phase it delivers ~0.28 kWh and it does not. Deliberately left
+        # unasserted — read `min_duty_guard_fired` in the report, then pin
+        # expect_min_duty_guard to whatever your config actually does, so a
+        # later config change that moves this boundary is caught.
+        #
+        # expect_scheduled is also left unchecked: if level_margin exceeds
+        # the requested delta, day_ahead.py correctly declines to schedule at
+        # all, and that is not this case's concern. What IS asserted is that
+        # the solve stays feasible and produces no slivers.
+        expect_min_duty_guard=None,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Log parsing
+# ---------------------------------------------------------------------------
+
+PAIR_RE = re.compile(r"(-?[\d.]+)\((-?[\d.]+)\)")
+ROW_RE = re.compile(r"^(\d{2}:\d{2})\s{2}(.*)$")
+
+_ECHO_INSTANT_RE = re.compile(r"Direct laden is (aan|uit)")
+_ECHO_READY_RE = re.compile(r"Klaar met laden op: (\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2})")
+_ECHO_ACTUAL_RE = re.compile(r"Huidig laadniveau: ([\d.]+) %")
+_ECHO_WISHED_RE = re.compile(r"Gewenst laadniveau:([\d.]+) %")
+_ECHO_POSITION_RE = re.compile(r"Locatie: (\S+)")
+_ECHO_PLUGGED_RE = re.compile(r"Ingeplugged:(True|False)")
+_ECHO_CAPACITY_RE = re.compile(r"Capaciteit accu: ([\d.]+) kWh")
+
+# Known capacities of the two mocked test cars — used as a cheap sanity
+# check that each EV's own log block shows ITS OWN config, not the other
+# car's (the exact class of bug the "two EVs simultaneously" fix addressed:
+# per-EV loop state leaking across cars). Update if the mocked configs
+# change.
+EV_CAPACITY_KWH = {"tesla": 55.0, "golf": 36.3}
+
+
+@dataclass
+class SetupEcho:
+    instant_charge: Optional[bool] = None
+    ready_dt: Optional[dt.datetime] = None
+    actual_soc: Optional[float] = None
+    wished_level: Optional[float] = None
+    position: Optional[str] = None
+    plugged_in: Optional[bool] = None
+    capacity_kwh: Optional[float] = None
+
+
+def parse_setup_echo(block_lines: list[str]) -> SetupEcho:
+    echo = SetupEcho()
+    for line in block_lines:
+        m = _ECHO_INSTANT_RE.search(line)
+        if m:
+            echo.instant_charge = m.group(1) == "aan"
+        m = _ECHO_READY_RE.search(line)
+        if m:
+            echo.ready_dt = dt.datetime.strptime(m.group(1), "%d-%m-%Y %H:%M:%S")
+        m = _ECHO_ACTUAL_RE.search(line)
+        if m:
+            echo.actual_soc = float(m.group(1))
+        m = _ECHO_WISHED_RE.search(line)
+        if m:
+            echo.wished_level = float(m.group(1))
+        m = _ECHO_POSITION_RE.search(line)
+        if m:
+            echo.position = m.group(1)
+        m = _ECHO_PLUGGED_RE.search(line)
+        if m:
+            echo.plugged_in = m.group(1) == "True"
+        m = _ECHO_CAPACITY_RE.search(line)
+        if m:
+            echo.capacity_kwh = float(m.group(1))
+    return echo
+
+
+def check_capacity(car_key: str, echo: SetupEcho) -> Optional[str]:
+    """Cheap cross-EV-leak sanity check: does this car's log block show
+    ITS OWN known capacity? A mismatch would mean the wrong EV's config
+    got read into this block — exactly the class of bug the "two EVs
+    simultaneously" PR fixed — so it's checked for both EVs on every case,
+    not just the dedicated two-EV case."""
+    expected = EV_CAPACITY_KWH.get(car_key)
+    if expected is None or echo.capacity_kwh is None:
+        return None
+    if abs(expected - echo.capacity_kwh) > 0.05:
+        return (
+            f"capacity sanity check ({car_key}): expected {expected} kWh, "
+            f"log shows {echo.capacity_kwh} kWh — possible EV index mix-up "
+            f"or cross-EV variable leak"
+        )
+    return None
+
+
+def verify_setup_echo(resolved: ResolvedEvInput, echo: SetupEcho) -> list[str]:
+    """Compare what we asked for against what the log says actually got
+    read. Only checks fields we explicitly set. A mismatch here means an
+    override silently didn't take effect (usually: the entity_id it should
+    have targeted is None/unconfigured for this EV) — see case 5.1."""
+    mismatches = []
+    if resolved.plugged_in is not None and echo.plugged_in is not None:
+        if resolved.plugged_in != echo.plugged_in:
+            mismatches.append(
+                f"plugged_in: requested {resolved.plugged_in}, log shows {echo.plugged_in}"
+            )
+    if resolved.position is not None and echo.position is not None:
+        if resolved.position.lower() != echo.position.lower():
+            mismatches.append(
+                f"position: requested {resolved.position!r}, log shows {echo.position!r}"
+            )
+    if resolved.actual_soc is not None and echo.actual_soc is not None:
+        if abs(resolved.actual_soc - echo.actual_soc) > 0.05:
+            mismatches.append(
+                f"actual_soc: requested {resolved.actual_soc}, log shows {echo.actual_soc}"
+            )
+    if resolved.instant_charge is not None and echo.instant_charge is not None:
+        if resolved.instant_charge != echo.instant_charge:
+            mismatches.append(
+                f"instant_charge: requested {resolved.instant_charge}, log shows "
+                f"{echo.instant_charge} (entity_instant_start is likely None/"
+                f"unconfigured for this EV — override had nothing to write to)"
+            )
+    if resolved.wished_level is not None and echo.wished_level is not None:
+        if abs(resolved.wished_level - echo.wished_level) > 0.05:
+            mismatches.append(
+                f"wished_level: requested {resolved.wished_level}, log shows "
+                f"{echo.wished_level}"
+            )
+    if resolved.ready_dt is not None and echo.ready_dt is not None:
+        delta = abs((resolved.ready_dt - echo.ready_dt).total_seconds())
+        if delta > 5:
+            mismatches.append(
+                f"ready_dt: requested {resolved.ready_dt}, log shows {echo.ready_dt} "
+                f"({delta:.0f}s off)"
+            )
+    return mismatches
+
+
+@dataclass
+class SolveStats:
+    wall_time_sec: Optional[float] = None
+    nodes: Optional[int] = None
+    gap: Optional[float] = None
+    objective: Optional[float] = None
+    cost_after_optimize: Optional[float] = None
+    # Whether the model actually reached an optimal solution. calc_optimum()
+    # returns None immediately on model.num_solutions == 0 (infeasible), or
+    # if self.strategy doesn't match a known value — BEFORE any EV dispatch
+    # logging (the per-interval factor table, partial/boundary/start-stop
+    # counts) ever runs. That means `scheduled` (parsed from the setup
+    # block, printed before model.optimize()) can still read True, and
+    # multi_stage_intervals is simply empty because there was no table to
+    # search — a fully infeasible solve would otherwise sail through this
+    # harness as a false PASS. Fail-closed: solved is only True if the
+    # exact success line is found, not merely "no failure line found".
+    solved: bool = False
+    failure_reason: Optional[str] = None
+
+
+_STATS_TIME_RE = re.compile(r"Rekentijd:\s*([\d.]+)\s*sec")
+_STATS_NODES_RE = re.compile(r"took \d+ iterations and (\d+) nodes")
+_STATS_GAP_RE = re.compile(r"Exiting as integer gap of ([\-\d.eE]+) less than")
+_STATS_OBJ_RE = re.compile(r"Search completed - best objective ([\-\d.eE]+),")
+_STATS_COST_RE = re.compile(r"Cost after optimize\s+([\-\d.]+)")
+_STATS_SUCCESS_RE = re.compile(
+    r"Het programma heeft een optimale oplossing gevonden\."
+)
+_STATS_FAILURE_RE = re.compile(
+    r"(Geen oplossing(?: in na herberekening)? voor: [^\n]*"
+    r"|Kies een strategie in options"
+    r"|Er is helaas geen oplossing gevonden[^\n]*)"
+)
+
+
+def parse_solve_stats(log_text: str) -> SolveStats:
+    stats = SolveStats()
+    m = _STATS_TIME_RE.search(log_text)
+    if m:
+        stats.wall_time_sec = float(m.group(1))
+    m = _STATS_NODES_RE.search(log_text)
+    if m:
+        stats.nodes = int(m.group(1))
+    m = _STATS_GAP_RE.search(log_text)
+    if m:
+        stats.gap = float(m.group(1))
+    m = _STATS_OBJ_RE.search(log_text)
+    if m:
+        stats.objective = float(m.group(1))
+    m = _STATS_COST_RE.search(log_text)
+    if m:
+        stats.cost_after_optimize = float(m.group(1))
+    stats.solved = bool(_STATS_SUCCESS_RE.search(log_text))
+    m = _STATS_FAILURE_RE.search(log_text)
+    if m:
+        stats.failure_reason = m.group(1)
+    return stats
+
+
+@dataclass
+class ParsedEvRun:
+    scheduled: Optional[bool] = None
+    reason: Optional[str] = None
+    energy_needed_kwh: Optional[float] = None
+    rows: list[dict] = field(default_factory=list)  # per-interval parsed data
+    partial_stops: Optional[int] = None
+    boundary_stops: Optional[int] = None
+    start_stops: Optional[int] = None
+    multi_stage_intervals: list[str] = field(default_factory=list)  # 'uur' values
+    # (uur, stage_index, factor) for every real stage running below the
+    # minimum duty cycle but above zero — i.e. a charge command too short to
+    # dispatch. Empty list is the passing state.
+    duty_slivers: list[tuple[str, int, float]] = field(default_factory=list)
+    # Smallest non-zero real-stage factor seen anywhere in the run. Reported
+    # rather than asserted: it is the number a human reads to judge whether a
+    # minimum-duty case is still provoking anything.
+    min_nonzero_factor: Optional[float] = None
+    # True iff day_ahead.py logged that it skipped the minimum-duty
+    # constraint because energy_needed was below one switching action.
+    min_duty_guard_fired: bool = False
+    # True iff day_ahead.py logged "Er is te weinig tijd" and clamped
+    # wished_level down for insufficient time before the deadline. For an
+    # instant_charge case this must never fire — instant charge is supposed
+    # to target the full wished level regardless of whatever
+    # entity_ready_datetime happens to hold. If it fires on an
+    # instant_charge case, that's Bug 7.
+    wished_level_clipped: bool = False
+    setup_echo: SetupEcho = field(default_factory=SetupEcho)
+
+
+def parse_ev_log(log_text: str, ev_name: str, min_duty: float = 0.0) -> ParsedEvRun:
+    result = ParsedEvRun()
+    lines = log_text.splitlines()
+
+    # setup block: "Instellingen voor laden van EV: {name}" ... next such
+    # line or end
+    setup_start = None
+    for i, line in enumerate(lines):
+        if line.startswith(f"Instellingen voor laden van EV: {ev_name}"):
+            setup_start = i
+            break
+    if setup_start is not None:
+        setup_end = len(lines)
+        for j in range(setup_start + 1, len(lines)):
+            if lines[j].startswith("Instellingen voor laden van EV:"):
+                setup_end = j
+                break
+        block = lines[setup_start:setup_end]
+        result.setup_echo = parse_setup_echo(block)
+        for line in block:
+            m = re.search(r"Benodigde netto energie: ([\d.]+) kWh", line)
+            if m:
+                result.energy_needed_kwh = float(m.group(1))
+            if "Er is te weinig tijd" in line:
+                result.wished_level_clipped = True
+            if "Opladen wordt niet ingepland, omdat" in line:
+                result.scheduled = False
+                result.reason = line.split("omdat", 1)[1].strip()
+            elif "Opladen wordt ingepland." in line:
+                result.scheduled = True
+
+    # factor table: "Inzet-factor laden {name} per stop" ... rows ... until
+    # a non-row line
+    for i, line in enumerate(lines):
+        if line == f"Inzet-factor laden {ev_name} per stop":
+            j = i + 2  # skip this line + header line
+            while j < len(lines):
+                m = ROW_RE.match(lines[j])
+                if not m:
+                    break
+                uur, rest = m.group(1), m.group(2)
+                try:
+                    pairs = PAIR_RE.findall(rest)
+                    remainder = PAIR_RE.sub("", rest)
+                    nums = [float(x) for x in remainder.split()]
+                    row = {
+                        "uur": uur,
+                        "stage_factors": [float(p[0]) for p in pairs],
+                        "stage_on": [float(p[1]) for p in pairs],
+                    }
+                    if len(nums) >= 9:
+                        (row["cons"], row["power"], row["on"], row["off"],
+                         row["part"], row["bound"], row["soc"], row["delta"],
+                         row["cost"]) = nums[:9]
+                    result.rows.append(row)
+                    real_active = [
+                        k for k, f in enumerate(row["stage_factors"])
+                        if k >= 1 and f > 1e-6
+                    ]
+                    if len(real_active) > 1:
+                        result.multi_stage_intervals.append(uur)
+                    # Minimum duty cycle: a real stage is either off or runs
+                    # for at least min_duty of the interval. Stage 0 is
+                    # deliberately exempt — its weight absorbs the idle
+                    # remainder, which is what makes partial duty possible at
+                    # all.
+                    for k, f in enumerate(row["stage_factors"]):
+                        if k < 1 or f <= DUTY_ZERO_TOL:
+                            continue
+                        if (result.min_nonzero_factor is None
+                                or f < result.min_nonzero_factor):
+                            result.min_nonzero_factor = f
+                        if min_duty > 0 and f < min_duty - DUTY_COMPARE_TOL:
+                            result.duty_slivers.append((uur, k, f))
+                except ValueError as ex:
+                    logging.warning(
+                        f"parse_ev_log: could not parse row {uur!r}: "
+                        f"{ex} — raw line: {lines[j]!r}"
+                    )
+                j += 1
+            break
+
+    # min-duty feasibility guard. Logged from the model-building loop, which
+    # runs after ALL the setup echo blocks, so this is scoped by EV name
+    # rather than by position in the log.
+    for line in lines:
+        if (f"EV {ev_name}:" in line
+                and "minimale schakelduur" in line
+                and "niet toegepast" in line):
+            result.min_duty_guard_fired = True
+            break
+
+    # summary lines, scoped after "wordt geladen tussen" / "is niet
+    # ingepland" for this ev, before the next ev's such line
+    anchor_idx = None
+    for i, line in enumerate(lines):
+        if (line.startswith(f"{ev_name} wordt geladen tussen")
+                or line == f"Laden van {ev_name} is niet ingepland"):
+            anchor_idx = i
+            break
+    if anchor_idx is not None:
+        for line in lines[anchor_idx:anchor_idx + 6]:
+            m = re.search(r"Aantal partial stops:\s*([\d.]+)", line)
+            if m:
+                result.partial_stops = int(float(m.group(1)))
+            m = re.search(r"Aantal boundary stops:\s*([\d.]+)", line)
+            if m:
+                result.boundary_stops = int(float(m.group(1)))
+            m = re.search(r"Aantal start/stops:\s*([\d.]+)", line)
+            if m:
+                result.start_stops = int(float(m.group(1)))
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def build_overrides(da_calc: DaCalc, ev_index: int, resolved: ResolvedEvInput) -> dict:
+    ev = da_calc.ev_options[ev_index]
+    overrides = {}
+    if resolved.plugged_in is not None:
+        overrides[ev.entity_plugged_in] = "on" if resolved.plugged_in else "off"
+    if resolved.position is not None:
+        overrides[ev.entity_position] = resolved.position
+    if resolved.actual_soc is not None:
+        overrides[ev.entity_actual_level] = resolved.actual_soc
+    if resolved.instant_charge is not None and ev.entity_instant_start is not None:
+        overrides[ev.entity_instant_start] = "on" if resolved.instant_charge else "off"
+    if resolved.wished_level is not None:
+        if resolved.instant_charge and ev.entity_instant_level is not None:
+            overrides[ev.entity_instant_level] = resolved.wished_level
+        elif ev.charge_scheduler is not None:
+            overrides[ev.charge_scheduler.entity_set_level] = resolved.wished_level
+    if resolved.ready_override_str is not None and ev.charge_scheduler is not None:
+        overrides[ev.charge_scheduler.entity_ready_datetime] = resolved.ready_override_str
+    elif resolved.ready_dt is not None and ev.charge_scheduler is not None:
+        overrides[ev.charge_scheduler.entity_ready_datetime] = (
+            resolved.ready_dt.strftime("%Y-%m-%d %H:%M:%S")
+        )
+    return overrides
+
+
+STATUS_PASS = "PASS"
+STATUS_FAIL = "FAIL"
+STATUS_MISMATCH = "SETUP_MISMATCH"
+STATUS_ERROR = "ERROR"
+STATUS_INFEASIBLE = "INFEASIBLE"
+
+
+@dataclass
+class CaseResult:
+    id: str
+    description: str
+    status: str
+    failures: list[str]
+    mismatches: list[str]
+    parsed: ParsedEvRun
+    stats: SolveStats
+
+
+def run_case(da_calc: DaCalc, case: TestCase, ev_index_tesla: int,
+             ev_index_golf: int) -> CaseResult:
+    target_index = ev_index_tesla if case.target == "tesla" else ev_index_golf
+    other_index = ev_index_golf if case.target == "tesla" else ev_index_tesla
+    target_name = da_calc.ev_options[target_index].name
+    other_name = da_calc.ev_options[other_index].name
+    other_key = "golf" if case.target == "tesla" else "tesla"
+
+    resolved_target = _resolve(da_calc, case.target_input)
+    resolved_other = _resolve(da_calc, case.other_input)
+
+    if case.soc_factory is not None:
+        # Derived from the target's real config, so it must run before
+        # build_overrides AND before verify_setup_echo reads resolved_target
+        # — the echo check is what catches a factory that silently computed
+        # something the model then didn't use.
+        resolved_target.actual_soc, resolved_target.wished_level = (
+            case.soc_factory(da_calc, target_index)
+        )
+
+    effective_start_dt = case.start_dt
+    if case.dynamic_setup is not None:
+        dyn_start, dyn_ready, dyn_ready_override = case.dynamic_setup(da_calc)
+        effective_start_dt = dyn_start
+        resolved_target.ready_dt = dyn_ready
+        if dyn_ready_override is not None:
+            resolved_target.ready_override_str = dyn_ready_override
+
+    overrides = {}
+    overrides.update(build_overrides(da_calc, target_index, resolved_target))
+    overrides.update(build_overrides(da_calc, other_index, resolved_other))
+
+    stop_entity_ctx = (
+        _with_stop_entity_removed(da_calc, target_index)
+        if case.remove_stop_entity_on_target
+        else _null_ctx()
+    )
+
+    with (stop_entity_ctx, get_state_overrides(da_calc, overrides),
+          capture_log() as buf, capture_native_stdout() as native):
+        try:
+            da_calc.debug = True  # see module docstring: not optional
+            da_calc.calc_optimum(_start_dt=effective_start_dt)
+        except Exception as ex:
+            log_text = buf.getvalue()
+            stats_text = log_text + "\n" + native["text"]
+            return CaseResult(
+                id=case.id, description=case.description, status=STATUS_ERROR,
+                failures=[f"EXCEPTION during solve: {ex!r}"], mismatches=[],
+                parsed=ParsedEvRun(), stats=parse_solve_stats(stats_text),
+            )
+
+    log_text = buf.getvalue()
+    native_text = native["text"]
+    min_duty = nominal_min_duty(da_calc)
+    parsed = parse_ev_log(log_text, target_name, min_duty)
+    parsed_other = parse_ev_log(log_text, other_name, min_duty)
+    stats = parse_solve_stats(log_text + "\n" + native_text)
+
+    if not stats.solved:
+        return CaseResult(
+            id=case.id, description=case.description, status=STATUS_INFEASIBLE,
+            failures=[
+                f"model did not reach an optimal solution "
+                f"({stats.failure_reason or 'no success line found in log'}) "
+                f"— calc_optimum() returns None before any EV dispatch "
+                f"logging runs, so 'scheduled' and multi-stage checks below "
+                f"would be misleadingly clean; this is checked first"
+            ],
+            mismatches=[], parsed=parsed, stats=stats,
+        )
+
+    mismatches = verify_setup_echo(resolved_target, parsed.setup_echo)
+    for note in (
+        check_capacity(case.target, parsed.setup_echo),
+        check_capacity(other_key, parsed_other.setup_echo),
+    ):
+        if note is not None:
+            mismatches.append(note)
+
+    if mismatches:
+        return CaseResult(
+            id=case.id, description=case.description, status=STATUS_MISMATCH,
+            failures=[], mismatches=mismatches, parsed=parsed, stats=stats,
+        )
+
+    failures: list[str] = []
+    if case.expect_scheduled is not None and parsed.scheduled != case.expect_scheduled:
+        failures.append(
+            f"expected scheduled={case.expect_scheduled}, got {parsed.scheduled}"
+        )
+    if case.expect_reason_substr and (
+        not parsed.reason or case.expect_reason_substr not in parsed.reason
+    ):
+        failures.append(
+            f"expected reason containing {case.expect_reason_substr!r}, "
+            f"got {parsed.reason!r}"
+        )
+    if parsed.multi_stage_intervals:
+        failures.append(
+            f"MULTIPLE REAL STAGES ACTIVE at: {parsed.multi_stage_intervals}"
+        )
+    # Other EV is checked on every case (cheap, and it's exactly the class
+    # of leak the two-EV-simultaneous fix addressed), not just when it's
+    # the deliberate focus of the case.
+    if parsed_other.multi_stage_intervals:
+        failures.append(
+            f"OTHER EV ({other_name}) MULTIPLE REAL STAGES ACTIVE at: "
+            f"{parsed_other.multi_stage_intervals}"
+        )
+    if (case.other_expect_scheduled is not None
+            and parsed_other.scheduled != case.other_expect_scheduled):
+        failures.append(
+            f"other EV ({other_name}): expected scheduled="
+            f"{case.other_expect_scheduled}, got {parsed_other.scheduled}"
+        )
+    # Minimum duty cycle — checked on EVERY case and on BOTH cars, same
+    # rationale as the multi-stage check above: it is cheap, and a sliver is
+    # not dispatchable regardless of which case happened to produce it.
+    for who, p in ((target_name, parsed), (f"OTHER EV ({other_name})", parsed_other)):
+        if p.duty_slivers:
+            detail = ", ".join(
+                f"{uur} stage {k} factor {f:.4f}" for uur, k, f in p.duty_slivers
+            )
+            failures.append(
+                f"{who}: DUTY SLIVER below minimum duty {min_duty:.4f} "
+                f"({EV_MIN_DUTY_S:.0f}s) at: {detail}"
+            )
+    if case.expect_partial_at_least is not None:
+        got = parsed.partial_stops
+        if got is None or got < case.expect_partial_at_least:
+            failures.append(
+                f"case no longer provokes partial duty: expected at least "
+                f"{case.expect_partial_at_least} partial interval(s), got "
+                f"{got}. This is a NEGATIVE test (asserts no slivers), so "
+                f"without a partial interval it passes while testing "
+                f"nothing — retune the engineered remainder rather than "
+                f"relaxing this bound."
+            )
+    if (case.expect_min_duty_guard is not None
+            and parsed.min_duty_guard_fired != case.expect_min_duty_guard):
+        failures.append(
+            f"expected min-duty feasibility guard fired="
+            f"{case.expect_min_duty_guard}, got {parsed.min_duty_guard_fired}"
+        )
+    if (case.expect_wished_level_clipped is not None
+            and parsed.wished_level_clipped != case.expect_wished_level_clipped):
+        failures.append(
+            f"wished_level_clipped: expected "
+            f"{case.expect_wished_level_clipped}, got "
+            f"{parsed.wished_level_clipped}"
+        )
+
+    status = STATUS_FAIL if failures else STATUS_PASS
+    return CaseResult(
+        id=case.id, description=case.description, status=status,
+        failures=failures, mismatches=[], parsed=parsed, stats=stats,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def write_reports(results: list[CaseResult], out_dir: Path = REPORT_DIR) -> tuple[Path, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    md_path = out_dir / f"ev_test_report_{timestamp}.md"
+    csv_path = out_dir / f"ev_test_report_{timestamp}.csv"
+    md_latest = out_dir / "ev_test_report_latest.md"
+    csv_latest = out_dir / "ev_test_report_latest.csv"
+
+    counts = {STATUS_PASS: 0, STATUS_FAIL: 0, STATUS_MISMATCH: 0,
+              STATUS_ERROR: 0, STATUS_INFEASIBLE: 0}
+    for r in results:
+        counts[r.status] = counts.get(r.status, 0) + 1
+
+    # --- Markdown ---
+    lines = []
+    lines.append(f"# EV charging test report — {dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append("")
+    lines.append(
+        f"**{counts[STATUS_PASS]} passed, {counts[STATUS_FAIL]} failed, "
+        f"{counts[STATUS_MISMATCH]} setup mismatch, {counts[STATUS_ERROR]} error, "
+        f"{counts[STATUS_INFEASIBLE]} infeasible** "
+        f"out of {len(results)} cases."
+    )
+    lines.append("")
+    lines.append(
+        "| ID | Status | Description | Scheduled | Energy needed (kWh) | "
+        "Partial/Boundary/Start-stops | Min factor | Solve (s / nodes / gap) |"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|")
+    for r in results:
+        sched = "—" if r.parsed.scheduled is None else str(r.parsed.scheduled)
+        energy = "—" if r.parsed.energy_needed_kwh is None else f"{r.parsed.energy_needed_kwh:.3f}"
+        psb = f"{r.parsed.partial_stops}/{r.parsed.boundary_stops}/{r.parsed.start_stops}"
+        solve = (
+            f"{r.stats.wall_time_sec or '—'} / {r.stats.nodes or '—'} / "
+            f"{r.stats.gap if r.stats.gap is not None else '—'}"
+        )
+        minf = (
+            "—" if r.parsed.min_nonzero_factor is None
+            else f"{r.parsed.min_nonzero_factor:.4f}"
+        )
+        lines.append(
+            f"| {r.id} | {r.status} | {r.description} | {sched} | {energy} | "
+            f"{psb} | {minf} | {solve} |"
+        )
+    lines.append("")
+
+    detail_needed = [r for r in results if r.status != STATUS_PASS]
+    if detail_needed:
+        lines.append("## Details for non-passing cases")
+        lines.append("")
+        for r in detail_needed:
+            lines.append(f"### {r.id} — {r.description} ({r.status})")
+            if r.mismatches:
+                lines.append("Setup-echo mismatches (override likely didn't take effect):")
+                for m in r.mismatches:
+                    lines.append(f"- {m}")
+            if r.failures:
+                lines.append("Assertion failures:")
+                for f in r.failures:
+                    lines.append(f"- {f}")
+            if r.parsed.reason:
+                lines.append(f"\nModel's stated reason: `{r.parsed.reason}`")
+            lines.append("")
+
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+    md_latest.write_text("\n".join(lines), encoding="utf-8")
+
+    # --- CSV ---
+    fieldnames = [
+        "id", "status", "description", "scheduled", "reason",
+        "energy_needed_kwh", "partial_stops", "boundary_stops", "start_stops",
+        "multi_stage_intervals", "duty_slivers", "min_nonzero_factor",
+        "min_duty_guard_fired", "wished_level_clipped", "failures", "mismatches",
+        "wall_time_sec", "nodes", "gap", "objective", "cost_after_optimize",
+    ]
+    rows = []
+    for r in results:
+        rows.append({
+            "id": r.id,
+            "status": r.status,
+            "description": r.description,
+            "scheduled": r.parsed.scheduled,
+            "reason": r.parsed.reason or "",
+            "energy_needed_kwh": r.parsed.energy_needed_kwh,
+            "partial_stops": r.parsed.partial_stops,
+            "boundary_stops": r.parsed.boundary_stops,
+            "start_stops": r.parsed.start_stops,
+            "multi_stage_intervals": ";".join(r.parsed.multi_stage_intervals),
+            "duty_slivers": ";".join(
+                f"{uur}/s{k}/{f:.4f}" for uur, k, f in r.parsed.duty_slivers
+            ),
+            "min_nonzero_factor": r.parsed.min_nonzero_factor,
+            "min_duty_guard_fired": r.parsed.min_duty_guard_fired,
+            "wished_level_clipped": r.parsed.wished_level_clipped,
+            "failures": " | ".join(r.failures),
+            "mismatches": " | ".join(r.mismatches),
+            "wall_time_sec": r.stats.wall_time_sec,
+            "nodes": r.stats.nodes,
+            "gap": r.stats.gap,
+            "objective": r.stats.objective,
+            "cost_after_optimize": r.stats.cost_after_optimize,
+        })
+    for path in (csv_path, csv_latest):
+        with path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    return md_path, csv_path
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    da_calc = DaCalc(CONFIG_PATH)
+    if da_calc.config is None:
+        print("Config failed to load — aborting.")
+        return
+
+    ev_index_tesla = _find_ev_index(da_calc, "Tesla")
+    ev_index_golf = _find_ev_index(da_calc, "Golf")
+
+    results: list[CaseResult] = []
+    for case in CASES:
+        r = run_case(da_calc, case, ev_index_tesla, ev_index_golf)
+        results.append(r)
+        print(f"[{r.status}] {r.id}: {r.description}")
+        if r.mismatches:
+            for m in r.mismatches:
+                print(f"        - MISMATCH: {m}")
+        if r.failures:
+            for f in r.failures:
+                print(f"        - {f}")
+        if r.parsed.energy_needed_kwh is not None:
+            print(f"        energy_needed={r.parsed.energy_needed_kwh:.3f} kWh, "
+                  f"partial_stops={r.parsed.partial_stops}, "
+                  f"boundary_stops={r.parsed.boundary_stops}, "
+                  f"start_stops={r.parsed.start_stops}")
+
+    n_pass = sum(1 for r in results if r.status == STATUS_PASS)
+    print(f"\n{n_pass}/{len(results)} passed.")
+    non_pass = [r.id for r in results if r.status != STATUS_PASS]
+    if non_pass:
+        print("Cases needing a look:", non_pass)
+
+    md_path, csv_path = write_reports(results)
+    print(f"\nReport written to:\n  {md_path}\n  {csv_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


usage: python -m dao.prog.da_debug [-h]
                                   {capture,replay,inspect,verify,diff,set,dump,selftest}
                                   ...

Capture, replay, and inspect calc_optimum() debug snapshots.

positional arguments:
  {capture,replay,inspect,verify,diff,set,dump,selftest}
    capture             Run a real optimisation; write snapshot + result.
    replay              Re-solve from a snapshot; needs no live HA/DB.
    inspect             Print snapshot meta and a content summary; no solve.
    verify              Schema version, config hash, secret scan, integrity.
    diff                Compare two snapshots (inputs) or two .result.json files.
    set                 Derive a new snapshot with overridden entity state(s).
    dump                Interval dump (stub — needs A3's variable registry).
    selftest            Run da_debug's own offline checks.

options:
  -h, --help            show this help message and exit
--data-dir and --json are accepted by every subcommand (put them after the subcommand name, e.g. capture --json, not before). Run from the repo root, or anywhere dao is importable — paths resolve from --data-dir, never from cwd.

capture — run a real optimisation

python -m dao.prog.da_debug capture [--config CONFIG] [--out-dir OUT_DIR]
    [--label LABEL] [--debug] [--png] [--start-dt START_DT]
    [--start-soc START_SOC] [--start-ev-soc START_EV_SOC]
--config — path to options.json (default <data-dir>/options.json). The only command that touches your real config file directly — migration rewrites can happen here, like an unwrapped run.
--out-dir — where the snapshot goes (default <data-dir>/debug_snapshots).
--label — suffix for the snapshot filename.
--debug — mirrors day_ahead.py's own debug mode: gates most writes, plus closes the two gaps self.debug alone doesn't cover (notify(), one set_value() call). Use while iterating so repeated captures don't push real settings to HA/DB.
--png — keep the chart PNG (off by default, independent of --debug).
--start-dt / --start-soc / --start-ev-soc — forwarded to calc_optimum() for a fixed scenario instead of "now."
replay — re-solve from a snapshot, no live HA/DB

python -m dao.prog.da_debug replay snapshot [--offline] [--allow-network]
    [--png] [--threads N] [--out-result PATH]
snapshot — bare filename resolves against <data-dir>/debug_snapshots/.
--offline (default) / --allow-network — blocks all network access during replay, failing loudly (exit 5) if anything tries; the escape hatch disables that.
--threads N — default -1 (matches whatever the capture itself used). --threads 1 gives bit-for-bit reproducibility at the cost of speed and possibly hitting the node cap before proving optimal.
--out-result PATH — where the replay's own .result.json goes (default: next to the snapshot, named per thread count so different --threads runs don't overwrite each other). Compare it with diff.
--png — keep the chart PNG (off by default).
inspect — summarize a snapshot, no solve

python -m dao.prog.da_debug inspect snapshot
Prints dao/mip/schema versions, captured-at/interval/strategy, channel counts (ha_states, price/prog data shape, baseload, heatpump run hours), how many secrets got redacted, and — if a .result.json sits next to it — objective/status/gap plus whether the CBC log shows a partial (node-capped) search.

verify — integrity check

python -m dao.prog.da_debug verify snapshot [--config CONFIG] [--secrets SECRETS]
No args beyond the snapshot: checks schema version, re-derives the config hash, and confirms every SecretStr field is actually redacted.
--config — also compares against a live options.json, via a disposable copy (never touches the real file).
--secrets — additionally scans the snapshot for literal values from a secrets.json, catching a raw credential pasted without !secret.
Exit 0 clean, exit 1 on any problem found.

diff — compare two snapshots or two results

python -m dao.prog.da_debug diff first second
Two snapshots: shows changed ha_states and meta fields. Two .result.json files: shows changed objective_value/objective_bound/status/gap/num_solutions.

set — derive a snapshot with overridden state

python -m dao.prog.da_debug set snapshot --state entity_id=value [--state ...] --out OUT
--state is repeatable. Writes a new snapshot with those ha_states entries overridden and everything else unchanged — the manual way to build a scenario.

dump — stub

python -m dao.prog.da_debug dump [--snapshot SNAPSHOT] [--interval INTERVAL]
Not implemented yet — needs the variable registry (A3). Exits 2 with a message saying so.

selftest — offline sanity checks

python -m dao.prog.da_debug selftest
No live stack needed; checks the DataFrame round-trip, _call_key, _config_hash, the secret-leak gate, and patch restore logic. Exit 0 pass, 1 fail.