### PR TITLE
Fix: pass API report field/period as str to avoid Markup in SQL

### DIFF
--- a/dao/webserver/app/routes.py
+++ b/dao/webserver/app/routes.py
@@ -967,8 +967,8 @@ def api_report(fld: str, periode: str):
             cumulate = cumulate == 1
         except ValueError:
             cumulate = False
-    fld = escape(fld)
-    periode = escape(periode)
+    fld = str(escape(fld))
+    periode = str(escape(periode))
     result = report.get_api_data(fld, periode, cumulate=cumulate)
 
     headers = {


### PR DESCRIPTION
escape() on fld and periode in /api/report/<fld>/<periode> passes a MarkupSafe Markup object into SQL. MariaDB then sees HTML entities (&#39;soc&#39;) instead of 'soc'