### PR TITLE
Report the legacy api with the configured optimizer interval

### DIFF
--- a/dao/CHANGELOG.md
+++ b/dao/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog 刀 DAO
 # Day Ahead Optimizer
 
+# Unreleased
+- The api (`/api/report/<variable>/<period>`) now returns the periods within a day ("vandaag",
+  "morgen", "vandaag_en_morgen" and "gisteren") with the resolution the optimizer calculates with:
+  quarter-hourly values when `interval` is `15min` instead of hourly values.
+  Because Home Assistant only keeps hourly long term statistics, already realised hourly values are
+  spread evenly over the four quarters of the hour; the forecasts keep the full quarter-hourly
+  resolution as calculated.
+- The pv forecast that extends "vandaag_en_morgen" for `pv_ac`/`pv_dc` now follows the configured
+  interval as well, instead of always being calculated hourly.
+- Fixed the timestamp of the last calculated SoC: it was always stored one hour after the last
+  interval, also when the optimizer runs with a 15 minutes interval.
+
 # 2026.9.0
 - Moved the runs of scheduler-tasks to a separate process, SIGABRT in CBC killed the scheduler (reported by @tomvandepoel3)
 - Added wget to succeed a local build of miplib (reported by @stat)

--- a/dao/DOCS.md
+++ b/dao/DOCS.md
@@ -1754,9 +1754,10 @@ Verder kun je nog de volgende variabelen opvragen:
 
 Bij **\<period>** kun je de periode opgeven waarover je de gevraagde gegevens wilt ontvangen. 
 Je kunt kiezen uit:
-- **vandaag** met interval uur
-- **vandaag_en_morgen** met interval uur
-- **morgen** met interval uur
+- **vandaag** met interval uur of kwartier
+- **vandaag_en_morgen** met interval uur of kwartier
+- **morgen** met interval uur of kwartier
+- **gisteren** met interval uur of kwartier
 - **deze_week** met interval dag
 - **vorige_week**  met interval dag
 - **deze_maand**  met interval dag
@@ -1764,6 +1765,13 @@ Je kunt kiezen uit:
 - **dit jaar** met interval maand
 - **vorig_jaar** met interval maand
 - **dit_contractjaar**  met interval maand
+
+De perioden binnen een dag volgen de resolutie waarmee de optimalisering rekent
+(de instelling **interval**): met `1hour` krijg je uurwaarden, met `15min` kwartierwaarden.
+Home Assistant bewaart zijn langetermijn-statistieken alleen per uur; bij een kwartier-interval
+worden de al gerealiseerde uurwaarden daarom gelijkmatig over de vier kwartieren van het uur
+verdeeld, zodat het totaal gelijk blijft. De prognoses komen wel met de volledige
+kwartier-resolutie terug zoals de optimalisering ze heeft berekend.
 
 Bij **pv_ac** en **pv_dc** wordt bij periode **vandaag_en_morgen** de voorspelling verlengd met een
 of twee dagen of tot zover stralingsgegevens bekend zijn.

--- a/dao/lib/db_manager.py
+++ b/dao/lib/db_manager.py
@@ -11,6 +11,9 @@ from sqlalchemy import (
     func,
     and_,
     text,
+    cast,
+    Integer,
+    String,
     TIMESTAMP,
 )
 import sqlalchemy_utils
@@ -202,6 +205,38 @@ class DBmanagerObj(object):
             return func.to_char(func.to_timestamp(column), "YYYY-MM-DD")
         else:  # mysql/mariadb
             return func.date(func.from_unixtime(column))
+
+    def quarter_start(self, column) -> func:
+        """
+        Het begin van het kwartier waarin "column" (een unix-timestamp) valt,
+        als "YYYY-MM-DD HH:MM".
+        """
+        if self.db_dialect == "sqlite":
+            moment = func.datetime(column, "unixepoch", "localtime")
+            return func.printf(
+                "%s:%02d",
+                func.strftime("%Y-%m-%d %H", moment),
+                (cast(func.strftime("%M", moment), Integer) / 15) * 15,
+            )
+        elif self.db_dialect == "postgresql":
+            moment = func.to_timestamp(column)
+            return func.concat(
+                func.to_char(moment, "YYYY-MM-DD HH24:"),
+                func.lpad(
+                    cast(
+                        cast(func.floor(func.extract("minute", moment) / 15) * 15, Integer),
+                        String,
+                    ),
+                    2,
+                    "0",
+                ),
+            )
+        else:  # mysql/mariadb
+            moment = func.from_unixtime(column)
+            return func.concat(
+                func.date_format(moment, "%Y-%m-%d %H:"),
+                func.lpad(func.floor(func.minute(moment) / 15) * 15, 2, "0"),
+            )
 
     def hour(self, column) -> func:
         if self.db_dialect == "sqlite":

--- a/dao/prog/da_report.py
+++ b/dao/prog/da_report.py
@@ -36,6 +36,26 @@ import matplotlib.pyplot as plt
 from sklearn.metrics import r2_score
 
 
+# Rapportage-intervallen die een deel van een dag beschrijven.
+# "kwartier" wordt gebruikt als de optimalisering met een resolutie van 15 minuten draait.
+INTRADAY_INTERVALS = ("uur", "kwartier")
+
+# De lengte van zo'n interval; wordt o.a. gebruikt om te bepalen vanaf welk moment
+# er geen gerealiseerde data meer is en de prognoses beginnen.
+INTERVAL_DELTA = {
+    "uur": datetime.timedelta(hours=1),
+    "kwartier": datetime.timedelta(minutes=15),
+}
+
+
+def interval_delta(interval: str) -> datetime.timedelta:
+    """
+    De lengte van een rapportage-interval binnen een dag,
+    voor "dag" en "maand" (die per uur worden opgehaald) is dat een uur.
+    """
+    return INTERVAL_DELTA.get(interval, datetime.timedelta(hours=1))
+
+
 def calc_r2(serie_x: pd.Series, serie_y: pd.Series) -> float:
     if serie_x.count() < 24 or serie_y.count() < 24:
         return pd.NA
@@ -55,6 +75,8 @@ class Report(DaBase):
         self.report_options = self.config.report
         if self.report_options is None:
             logging.error(f"Er zijn geen report-instellingen gevonden")
+        # het kleinste rapportage-interval volgt de resolutie van de optimalisering
+        self.report_interval = "kwartier" if self.interval == "15min" else "uur"
         self.make_periodes(_now=_now)
         _r = self.report_options
         self.grid_consumption_sensors = _r.entities_grid_consumption if _r else []
@@ -907,10 +929,16 @@ class Report(DaBase):
         :param vanaf: begin date/time
         :param tot: end date/time
         :param col_name: name off the column in the df
-        :param agg: "maand", "dag" or "uur"
+        :param agg: "maand", "dag", "uur" of "kwartier"
         :param sensor_type: "quantity" of "factor"
         :return: dataframe with the data
         """
+        # Home Assistant bewaart zijn langetermijn-statistieken alleen per uur.
+        # Bij een kwartier-rapportage worden de opgehaalde uurwaarden achteraf
+        # over de vier kwartieren van het uur verdeeld.
+        to_quarters = agg == "kwartier"
+        if to_quarters:
+            agg = "uur"
         """
         if agg == "uur":
             sql = "SELECT FROM_UNIXTIME(t2.`start_ts`) 'tijd', " \
@@ -1131,6 +1159,10 @@ class Report(DaBase):
                 df_insert.index = df_insert["tijd"]
                 df_raw = pd.concat([df_raw, df_insert])
                 df_raw.sort_index(inplace=True)
+        if to_quarters:
+            df_raw = self.spread_over_quarters(
+                df_raw, [col_name], quantity=sensor_type == "quantity"
+            )
         logging.debug(f"sensordata raw, sensor {sensor},\n {df_raw.to_string()}\n")
         return df_raw
 
@@ -1255,6 +1287,61 @@ class Report(DaBase):
                             org_value + factor * row[col_index]
                     )
         return add_to
+
+    @staticmethod
+    def spread_over_quarters(
+            df: pd.DataFrame,
+            value_columns: list,
+            quantity: bool = True,
+            time_column: str = "tijd",
+            label_column: str | None = None,
+    ) -> pd.DataFrame:
+        """
+        Zet uurwaarden om in kwartierwaarden.
+        Home Assistant bewaart zijn langetermijn-statistieken (en dus ook de
+        gerealiseerde waarden in de da-database) alleen per uur. Als er per kwartier
+        gerapporteerd wordt, worden die uurwaarden gelijkmatig over de vier kwartieren
+        van het uur verdeeld, zodat de reeks een vaste stapgrootte houdt en het totaal
+        gelijk blijft.
+        :param df: dataframe met uurwaarden
+        :param value_columns: de kolommen met de te verdelen waarden
+        :param quantity: True bij hoeveelheden (worden gedeeld door 4),
+            False bij een gemiddelde/tarief (wordt overgenomen)
+        :param time_column: de kolom met het begintijdstip
+        :param label_column: als != None de kolom met het interval-label
+        :return: dataframe met kwartierwaarden
+        """
+        if df is None or len(df) == 0:
+            return df
+        moments = pd.to_datetime(df[time_column])
+        if len(moments) > 1:
+            spacing = moments.diff().dropna().min()
+            if pd.notnull(spacing) and spacing < datetime.timedelta(hours=1):
+                # de data heeft al een fijnere resolutie dan een uur
+                return df
+        rows = []
+        for row in df.to_dict("records"):
+            start = pd.to_datetime(row[time_column])
+            if pd.isnull(start):
+                continue
+            for quarter in range(4):
+                moment = start + datetime.timedelta(minutes=15 * quarter)
+                new_row = dict(row)
+                for col in (time_column, "tijd", "vanaf", "tot"):
+                    if col in new_row:
+                        new_row[col] = moment
+                if "utc" in new_row:
+                    new_row["utc"] = moment.timestamp()
+                if label_column is not None and label_column in new_row:
+                    new_row[label_column] = moment.strftime("%Y-%m-%d %H:%M")
+                if quantity:
+                    for col in value_columns:
+                        if col in new_row and is_number(new_row[col]):
+                            new_row[col] = new_row[col] / 4
+                rows.append(new_row)
+        result = pd.DataFrame(rows, columns=df.columns)
+        result.index = pd.to_datetime(result[time_column])
+        return result
 
     def get_latest_present(self, code: str) -> datetime.datetime:
         """
@@ -1412,7 +1499,9 @@ class Report(DaBase):
                 continue
             if not isinstance(row.tijd, datetime.datetime):
                 print(row)
-            if interval == "uur":
+            if interval == "kwartier":
+                tijd_str = str(row.tijd)[0:14] + f"{(row.tijd.minute // 15) * 15:02d}"
+            elif interval == "uur":
                 tijd_str = str(row.tijd)[0:14] + "00"
             elif interval == "dag":
                 tijd_str = str(row.tijd)[0:10]
@@ -1432,7 +1521,7 @@ class Report(DaBase):
             fi_df.loc[fi_df.shape[0]] = [
                 tijd_str,
                 row.tijd,
-                row.tijd + datetime.timedelta(hours=1),
+                row.tijd + interval_delta(interval),
                 col_1,
                 col_2,
                 col_3,
@@ -1563,14 +1652,14 @@ class Report(DaBase):
             else:
                 old_moment = moment
             moment_str = str(moment)
-            if rep_interval == "uur":
+            if rep_interval in INTRADAY_INTERVALS:
                 tijd_str = moment_str[10:16]
             elif rep_interval == "dag":
                 tijd_str = moment_str[0:10]
             else:  # maand
                 tijd_str = moment_str[0:7]  # jaar maand
-            if step_interval == "uur":
-                moment = moment + datetime.timedelta(hours=1)
+            if step_interval in INTRADAY_INTERVALS:
+                moment = moment + interval_delta(step_interval)
             elif step_interval == "dag":
                 moment = moment + datetime.timedelta(days=1)
             else:  # "maand":
@@ -1628,6 +1717,8 @@ class Report(DaBase):
             column = self.db_da.month(t1.c.time).label("maand")
         elif interval == "dag":
             column = self.db_da.day(t1.c.time).label("dag")
+        elif interval == "kwartier":
+            column = self.db_da.quarter_start(t1.c.time).label("kwartier")
         else:  # interval == "uur"
             if interval == periode_d["interval"]:
                 column = self.db_da.hour(t1.c.time).label("uur")
@@ -1714,8 +1805,12 @@ class Report(DaBase):
                 # datetime.datetime.combine(vanaf, datetime.time(0,0)) - datetime.timedelta(hours=1)
                 last_moment = vanaf
             else:
+                if interval == "kwartier":
+                    code_result = self.spread_over_quarters(
+                        code_result, [key], label_column="kwartier"
+                    )
                 self.add_col_df(code_result, result, key)
-                last_moment = code_result["tot"].iloc[-1] + datetime.timedelta(hours=1)
+                last_moment = code_result["tot"].iloc[-1] + interval_delta(interval)
             if last_moment < tot:
                 ha_result = None
                 if categorie["sensors"] == "calc":
@@ -1748,8 +1843,8 @@ class Report(DaBase):
                             vanaf,
                         )
                     else:
-                        last_moment = ha_result["tot"].iloc[-1] + datetime.timedelta(
-                            hours=1
+                        last_moment = ha_result["tot"].iloc[-1] + interval_delta(
+                            interval
                         )
                 else:
                     last_moment = vanaf
@@ -1824,9 +1919,13 @@ class Report(DaBase):
                 .group_by(groupby_str)
             )
                 """
+                if interval == "kwartier":
+                    prog_column = self.db_da.quarter_start(p1.c.time).label("kwartier")
+                else:
+                    prog_column = self.db_da.hour_start(p1.c.time).label("uur")
                 query = (
                     select(
-                        self.db_da.hour_start(p1.c.time).label("uur"),
+                        prog_column,
                         func.min(self.db_da.from_unixtime(p1.c.time)).label("tijd"),
                         func.sum(p1.c.value).label(key),
                     )
@@ -1844,7 +1943,7 @@ class Report(DaBase):
                             ),
                         )
                     )
-                    .group_by("uur")
+                    .group_by(prog_column.name)
                 )
 
                 with self.db_da.engine.connect() as connection:
@@ -1859,9 +1958,7 @@ class Report(DaBase):
                 prog_result.index = pd.to_datetime(prog_result["tijd"])
                 if len(prog_result) > 0:
                     self.add_col_df(prog_result, result, key)
-                    last_moment = prog_result["tot"].iloc[-1] + datetime.timedelta(
-                        hours=1
-                    )
+                    last_moment = prog_result["tot"].iloc[-1] + interval_delta(interval)
             if categorie["sensors"] == "calc":
                 function = categorie["function"]
                 result = getattr(self, function)(result)
@@ -2071,10 +2168,16 @@ class Report(DaBase):
             interval = _interval if _interval else periode_d["interval"]
 
         source = _source
+        # Home Assistant levert alleen uurwaarden; get_sensor_data verdeelt die
+        # zonodig over de kwartieren van het uur.
+        ha_interval = interval if interval in INTRADAY_INTERVALS else "uur"
+        price_interval = "15min" if interval == "kwartier" else "1hour"
         if interval == "maand":
             column = self.db_da.month(t1.c.time).label("maand")
         elif interval == "dag":
             column = self.db_da.day(t1.c.time).label("dag")
+        elif interval == "kwartier":
+            column = self.db_da.quarter_start(t1.c.time).label("kwartier")
         else:  # interval == "uur"
             column = self.db_da.hour(t1.c.time).label("uur")
         result = None
@@ -2123,7 +2226,7 @@ class Report(DaBase):
         else:
             result = pd.DataFrame(
                 columns=[
-                    "uur",
+                    interval,
                     "vanaf",
                     "tot",
                     "consumption",
@@ -2132,7 +2235,7 @@ class Report(DaBase):
                     "profit",
                 ]
             )
-            result.index = result["uur"]  # vanaf
+            result.index = result[interval]  # vanaf
 
         result["datasoort"] = "recorded"
         # aanvullende prijzen ophalen
@@ -2142,7 +2245,14 @@ class Report(DaBase):
         else:
             result["vanaf"] = pd.to_datetime(result["vanaf"])
             result["tot"] = pd.to_datetime(result["tot"])
-            last_moment = result["tot"].iloc[-1] + datetime.timedelta(hours=1)
+            if interval == "kwartier":
+                result = self.spread_over_quarters(
+                    result,
+                    ["consumption", "production", "cost", "profit"],
+                    time_column="vanaf",
+                    label_column="kwartier",
+                )
+            last_moment = result["tot"].iloc[-1] + interval_delta(interval)
         if last_moment < tot:
             """
             # get the prices:
@@ -2181,13 +2291,13 @@ class Report(DaBase):
                 for sensor in self.grid_consumption_sensors:
                     if count == 0:
                         df_ha = self.get_sensor_data(
-                            sensor, last_moment, tot, "consumption", "uur"
+                            sensor, last_moment, tot, "consumption", ha_interval
                         )
                         df_ha.index = pd.to_datetime(df_ha["tijd"])
                         df_ha["tijd"] = pd.to_datetime(df_ha["tijd"])
                     else:
                         df_2 = self.get_sensor_data(
-                            sensor, last_moment, tot, "consumption", "uur"
+                            sensor, last_moment, tot, "consumption", ha_interval
                         )
                         df_2.index = pd.to_datetime(df_2["tijd"])
                         df_ha = self.add_col_df(df_2, df_ha, "consumption")
@@ -2198,7 +2308,7 @@ class Report(DaBase):
                 count = 0
                 for sensor in self.grid_production_sensors:
                     df_p = self.get_sensor_data(
-                        sensor, last_moment, tot, "production", "uur"
+                        sensor, last_moment, tot, "production", ha_interval
                     )
                     df_p.index = pd.to_datetime(df_p["tijd"])
                     if count == 0:
@@ -2207,11 +2317,22 @@ class Report(DaBase):
                         df_ha = self.add_col_df(df_p, df_ha, "production")
                     count = +1
                 if len(df_ha) > 0:
-                    last_moment = df_ha["tijd"].iloc[-1] + datetime.timedelta(hours=1)
+                    last_moment = df_ha["tijd"].iloc[-1] + interval_delta(interval)
                     df_ha["datasoort"] = "recorded"
                 else:
                     last_moment = vanaf
-                df_prices = self.get_price_data(vanaf, last_moment, interval="1hour")
+                df_prices = self.get_price_data(
+                    vanaf, last_moment, interval=price_interval
+                )
+                if interval == "kwartier":
+                    # een tarief is geen hoeveelheid: een uurtarief geldt
+                    # onverdeeld voor elk kwartier van dat uur
+                    df_prices = self.spread_over_quarters(
+                        df_prices,
+                        ["da_ex", "da_cons", "da_prod"],
+                        quantity=False,
+                        time_column="time",
+                    )
 
             if source == "all" or source == "da":
                 if last_moment < tot:
@@ -3243,9 +3364,7 @@ class Report(DaBase):
             solar_num = len(self.solar)
             for s in range(solar_num):
                 solar_option = self.solar[s]
-                df_data = self.calc_solar_predictions(
-                    solar_option, vanaf, tot, interval="1hour"
-                )
+                df_data = self.calc_solar_predictions(solar_option, vanaf, tot)
                 if s == 0:
                     df_result = df_data
                 else:
@@ -3264,9 +3383,7 @@ class Report(DaBase):
                 solar_num = len(solar_options)
                 for s in range(solar_num):
                     solar_option = solar_options[s]
-                    df_data = self.calc_solar_predictions(
-                        solar_option, vanaf, tot, interval="1hour"
-                    )
+                    df_data = self.calc_solar_predictions(solar_option, vanaf, tot)
                     if count == 0:
                         df_result = df_data
                     else:
@@ -3300,9 +3417,17 @@ class Report(DaBase):
             "netto_cost",
         ]
         tot = self.periodes[periode]["tot"]
+        # De api rapporteert met de resolutie waarmee de optimalisering rekent:
+        # per kwartier als het interval "15min" is, anders per uur.
+        # Bij de langere perioden (dag/maand) blijft de aggregatie ongewijzigd.
+        interval = (
+            self.report_interval
+            if self.periodes[periode]["interval"] in INTRADAY_INTERVALS
+            else None
+        )
         df = pd.DataFrame()
         if field in ["grid"] + grid_fields:  # grid data
-            df_grid = self.get_grid_data(periode, _tot=tot)
+            df_grid = self.get_grid_data(periode, _tot=tot, _interval=interval)
             df_grid["time"] = df_grid["vanaf"].apply(
                 lambda x: pd.to_datetime(x).strftime("%Y-%m-%d %H:%M")
             )
@@ -3333,7 +3458,7 @@ class Report(DaBase):
             else:
                 dict = self.energy_balance_dict
             df_balance, last_moment = self.get_energy_balance_data(
-                periode, field=field, _tot=tot, col_dict=dict
+                periode, field=field, _tot=tot, col_dict=dict, _interval=interval
             )
             df_balance["time"] = df_balance["tijd"]
             df = df_balance[["time", field, "datasoort"]].copy()

--- a/dao/prog/day_ahead.py
+++ b/dao/prog/day_ahead.py
@@ -3613,7 +3613,7 @@ class DaCalc(DaBase):
         df_soc = pd.DataFrame(columns=["tijd", "soc"])
         df_soc.index = pd.to_datetime(df_soc["tijd"])
         tijd_soc = tijd.copy()
-        tijd_soc.append(tijd_soc[U - 1] + datetime.timedelta(hours=1))
+        tijd_soc.append(tijd_soc[U - 1] + dt.timedelta(seconds=self.interval_s))
         if B > 0:
             for b in range(B):
                 df_soc["soc_" + str(b)] = None

--- a/dao/tests/prog/test_interval.py
+++ b/dao/tests/prog/test_interval.py
@@ -1,0 +1,117 @@
+"""
+Tests voor de kwartier-resolutie in de rapportage/api.
+
+Deze tests raken de database niet: ze controleren de hulpfuncties die bepalen
+met welke stapgrootte de legacy-api ("/api/report/<veld>/<periode>") zijn
+gegevens teruggeeft als de optimalisering met interval "15min" draait.
+"""
+
+import datetime
+import sys
+
+import pandas as pd
+
+sys.path.append("../../../dao/prog")
+from dao.prog.da_report import INTRADAY_INTERVALS, Report, interval_delta
+
+
+def test_interval_delta():
+    assert interval_delta("kwartier") == datetime.timedelta(minutes=15)
+    assert interval_delta("uur") == datetime.timedelta(hours=1)
+    # dag en maand worden per uur opgehaald
+    assert interval_delta("dag") == datetime.timedelta(hours=1)
+    assert interval_delta("maand") == datetime.timedelta(hours=1)
+
+
+def test_intraday_intervals():
+    assert "uur" in INTRADAY_INTERVALS
+    assert "kwartier" in INTRADAY_INTERVALS
+
+
+def test_generate_df_kwartier():
+    vanaf = datetime.datetime(2025, 4, 6)
+    tot = vanaf + datetime.timedelta(days=1)
+    result = Report.generate_df(vanaf, tot, "kwartier")
+    assert len(result) == 96
+    assert result["tijd"].iloc[1] - result["tijd"].iloc[0] == datetime.timedelta(
+        minutes=15
+    )
+    assert result["tijd"].iloc[-1] == tot - datetime.timedelta(minutes=15)
+
+
+def test_generate_df_uur_ongewijzigd():
+    vanaf = datetime.datetime(2025, 4, 6)
+    tot = vanaf + datetime.timedelta(days=1)
+    result = Report.generate_df(vanaf, tot, "uur")
+    assert len(result) == 24
+
+
+def test_generate_df_dag_met_kwartierstappen():
+    """Een dag-rapport dat per kwartier wordt opgehaald houdt dag-labels."""
+    vanaf = datetime.datetime(2025, 4, 6)
+    tot = vanaf + datetime.timedelta(days=2)
+    result = Report.generate_df(vanaf, tot, "dag", "kwartier")
+    assert len(result) == 192
+    assert set(result["dag"]) == {"2025-04-06", "2025-04-07"}
+
+
+def test_spread_over_quarters_verdeelt_hoeveelheid():
+    tijden = [
+        datetime.datetime(2025, 4, 6, 9),
+        datetime.datetime(2025, 4, 6, 10),
+    ]
+    df = pd.DataFrame({"tijd": tijden, "tot": tijden, "cons": [2.0, 4.0]})
+    df.index = pd.to_datetime(df["tijd"])
+    result = Report.spread_over_quarters(df, ["cons"])
+    assert len(result) == 8
+    assert list(result["cons"]) == [0.5] * 4 + [1.0] * 4
+    # het totaal blijft gelijk
+    assert result["cons"].sum() == df["cons"].sum()
+    assert result["tijd"].iloc[1] == datetime.datetime(2025, 4, 6, 9, 15)
+
+
+def test_spread_over_quarters_neemt_tarief_over():
+    tijden = [datetime.datetime(2025, 4, 6, 9), datetime.datetime(2025, 4, 6, 10)]
+    df = pd.DataFrame({"time": tijden, "da_cons": [0.25, 0.30]})
+    df.index = pd.to_datetime(df["time"])
+    result = Report.spread_over_quarters(
+        df, ["da_cons"], quantity=False, time_column="time"
+    )
+    assert list(result["da_cons"]) == [0.25] * 4 + [0.30] * 4
+
+
+def test_spread_over_quarters_laat_kwartierdata_ongemoeid():
+    tijden = [
+        datetime.datetime(2025, 4, 6, 9) + datetime.timedelta(minutes=15 * i)
+        for i in range(4)
+    ]
+    df = pd.DataFrame({"tijd": tijden, "cons": [0.5, 0.5, 0.5, 0.5]})
+    df.index = pd.to_datetime(df["tijd"])
+    result = Report.spread_over_quarters(df, ["cons"])
+    assert len(result) == 4
+    assert list(result["cons"]) == [0.5] * 4
+
+
+def test_recalc_df_ha_behoudt_kwartieren():
+    """Kwartierprognoses mogen niet tot uurwaarden worden samengevoegd."""
+    tijden = [
+        datetime.datetime(2025, 4, 6, 9) + datetime.timedelta(minutes=15 * i)
+        for i in range(4)
+    ]
+    df = pd.DataFrame(
+        {
+            "tijd": tijden,
+            "consumption": [0.5] * 4,
+            "production": [0.2] * 4,
+            "da_cons": [0.30] * 4,
+            "da_prod": [0.10] * 4,
+            "datasoort": ["expected"] * 4,
+        }
+    )
+    per_kwartier = Report.recalc_df_ha(None, df, "kwartier")
+    assert len(per_kwartier) == 4
+    assert per_kwartier["consumption"].sum() == 2.0
+
+    per_uur = Report.recalc_df_ha(None, df, "uur")
+    assert len(per_uur) == 1
+    assert per_uur["consumption"].iloc[0] == 2.0


### PR DESCRIPTION
The legacy api (/api/report/<variable>/<period>) always aggregated its data per hour, also when the optimizer runs with interval "15min". The quarter-hourly forecasts the optimizer stores in the "prognoses" table were summed into hourly buckets before they reached the api, so consumers such as apex-charts in Home Assistant could never show the quarter-hourly plan.

The periods within a day ("vandaag", "morgen", "vandaag_en_morgen" and "gisteren") now follow the resolution of the optimizer:

- added a "kwartier" report interval, with a quarter_start() grouping helper for sqlite, postgresql and mysql/mariadb;
- generate_df(), recalc_df_ha() and the last_moment bookkeeping now step with the length of the report interval instead of a hard coded hour;
- the forecast queries in get_energy_balance_data() group per quarter instead of per hour, so the calculated values are no longer summed into hours;
- Home Assistant only keeps hourly long term statistics, so already realised hourly values are spread evenly over the four quarters of the hour (spread_over_quarters()); the total stays the same and the series keeps a fixed step size. Tariffs are copied instead of divided.

Also fixed two related interval mismatches:

- get_pv_prognose() calculated the pv forecast that extends "vandaag_en_morgen" always hourly instead of with the configured interval;
- the timestamp of the last calculated SoC was stored one hour after the last interval instead of one interval.

The longer periods (day/month) and the report pages of the dashboard keep their existing aggregation; for an installation with interval "1hour" the api output is unchanged.


Claude-Session: https://claude.ai/code/session_0133s4ncpB1LFtekjpUt9i7L