### PR TITLE
Bugfix: Keep a cancelled task reported as cancelled instead of error

### DIFF
--- a/dao/webserver/app/v2/routes.py
+++ b/dao/webserver/app/v2/routes.py
@@ -150,14 +150,25 @@ def run_and_log(cmd, state):
         text=True,
     )
 
+    cancelled = False
+
     while proc.poll() is None:
         updated_state = get_task_state()
 
         if updated_state.get("status") == "cancelled":
-            if state["logfile"] and os.path.exists(state["logfile"]):
+            # Alleen afbreken zolang de taak nog loopt. Is ze tussen de poll
+            # hierboven en dit punt uit zichzelf klaar gekomen, dan telt haar
+            # eigen resultaat en blijft haar log staan.
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+                # Een door een signaal gedood proces levert een negatieve
+                # returncode; iets anders betekent dat het net zelf stopte.
+                cancelled = proc.returncode is not None and proc.returncode < 0
+
+            if cancelled and state["logfile"] and os.path.exists(state["logfile"]):
                 os.remove(state["logfile"])
 
-            proc.kill()
             break
 
         if state["logfile"] is None:
@@ -199,7 +210,13 @@ def run_and_log(cmd, state):
     if updated_state["logfile"] == state["logfile"]:
         print("Task completed")
         print(proc.returncode)
-        state["status"] = "done" if proc.returncode == 0 else "error"
+        if cancelled:
+            # De taak is op verzoek afgebroken. De returncode van het gedode
+            # proces zegt niets over het resultaat, dus die mag "cancelled"
+            # niet overschrijven met "error".
+            state["status"] = "cancelled"
+        else:
+            state["status"] = "done" if proc.returncode == 0 else "error"
         state["returncode"] = proc.returncode
         save_task_state(state)
 


### PR DESCRIPTION
## Issue

Cancelling a task from the web UI leaves it reported as `error` rather than `cancelled`.

`run_and_log` polls the state file while the task runs. When it sees `status: cancelled` it deletes the log file, kills the process and breaks out of the loop. After the loop it writes the final state:

```python
updated_state = get_task_state()

if updated_state["logfile"] == state["logfile"]:
    state["status"] = "done" if proc.returncode == 0 else "error"
    state["returncode"] = proc.returncode
    save_task_state(state)
```

A killed process has a non-zero return code (`-9`), so this overwrites `cancelled` with `error`. The `logfile` guard above it does not prevent this: `/v2/task-cancel` writes the state back with the path unchanged, so the two still match and the branch is taken.

The result is that the user presses cancel, the task is duly cancelled, and the UI then reports a failure that never happened.

## The fix

A flag records that the loop actually broke out because of a cancellation, and the final write respects it:

```python
if cancelled:
    state["status"] = "cancelled"
else:
    state["status"] = "done" if proc.returncode == 0 else "error"
```

The return code is still recorded, so `-9` remains visible for anyone who wants it.

The flag is deliberately set at the kill site rather than re-reading `status` from the file at the end. Re-reading would misreport a task that finished successfully in the same second a cancellation arrived — the process was never killed, so it should still be `done`. With the flag, `cancelled` is reported only when the process really was killed.

The other `break` in that loop — the one for "another task took over this log file" — is unaffected: it already fails the `logfile` comparison, so nothing is written for it.

## Testing

There is no test harness for the webserver in this repository, and Flask is not installed in the environment I worked in, so I drove `run_and_log` directly: the function source is extracted from `v2/routes.py` and executed against a stub `Popen`, a stub state store and a no-op `sleep`, then run through two scenarios.

Against `main`:

```
  taak afgebroken tijdens het draaien    -> status='error' returncode=-9 killed=True
  taak draait normaal af                 -> status='done' returncode=0 killed=False

FOUT:
  - afgebroken taak eindigt als 'error' in plaats van "cancelled"
```

Against this branch:

```
  taak afgebroken tijdens het draaien    -> status='cancelled' returncode=-9 killed=True
  taak draait normaal af                 -> status='done' returncode=0 killed=False

OK: afbreken levert 'cancelled', normaal afronden levert 'done'.
```

So the bug reproduces on `main` and is gone here, and a normally completing task is unchanged. That is a harness around the real function, not a test against a running server — worth a manual cancel on a live install before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjC7cNa3b6CYw8CqFjcbNQ

